### PR TITLE
Fix one source of config disconnect problem

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/physical_web/org/physicalweb/MainActivity.java
+++ b/android/PhysicalWeb/app/src/main/java/physical_web/org/physicalweb/MainActivity.java
@@ -48,7 +48,7 @@ public class MainActivity extends Activity {
 
   private void showNearbyBeaconsFragment() {
     getFragmentManager().beginTransaction()
-        .add(R.id.homeScreen_container, NearbyDevicesFragment.newInstance())
+        .add(R.id.main_activity_container, NearbyDevicesFragment.newInstance())
         .commit();
   }
 

--- a/android/PhysicalWeb/app/src/main/res/layout/activity_main.xml
+++ b/android/PhysicalWeb/app/src/main/res/layout/activity_main.xml
@@ -4,12 +4,4 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity"
     android:id="@+id/main_activity_container">
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:id="@+id/homeScreen_container">
-    </LinearLayout>
-
 </RelativeLayout>


### PR DESCRIPTION
The MainActivity is using a fragment stack on a container for About and
Config but a different stack on a different container for
NearbyDevices. The result is a missing onPause call when entering
BeaconConfigFragment. This kept the BLE scan running at LOW_LATENCY.
Scanning and GATT connections cannot occur at the same time so this was
causing a problem.
