### PR TITLE
codebender.cc instructions for Arduino firmware

### DIFF
--- a/firmware/arduino/README.md
+++ b/firmware/arduino/README.md
@@ -20,25 +20,26 @@ See [Arduino BLEPeripheral's Compatible Hardware](https://github.com/sandeepmist
 
 [RedBearLab](http://redbearlab.com) products can be purchased from [Seeed Studio](http://www.seeedstudio.com/depot/RedBearLab-m-52.html).
 
+## Using Arduino IDE
 
-### Setup
+#### Setup
 
 Install the [Arduino BLEPeripheral](https://github.com/sandeepmistry/arduino-BLEPeripheral) library. See [Installing Additional Arduino Libraries](http://arduino.cc/en/Guide/Libraries) guide for more info.
 
-#### OS X and Linux
+##### OS X and Linux
 ```
 cd ~/Documents/Arduino/libraries/
 git clone https://github.com/sandeepmistry/arduino-BLEPeripheral BLEPeripheral
 ```
 
-### Windows
+#### Windows
 
 ```
 cd "My Documents\Arduino\libraries\"
 git clone https://github.com/sandeepmistry/arduino-BLEPeripheral BLEPeripheral
 ```
 
-### Running
+#### Running
 
  1. Open [physical_web.ino](physical_web/physical_web.ino) sketch
  1. Update pin outs in sketch based on hardware setup (```URI_BEACON_REQ```, ```URI_BEACON_RDY```, ```URI_BEACON_RST```)
@@ -46,6 +47,15 @@ git clone https://github.com/sandeepmistry/arduino-BLEPeripheral BLEPeripheral
  1. Build and upload to board
 
 __Notes__
-  * only 15 bytes (instead of 18) are available for the URI, because GAP flags (3 bytes) are in advertisement data
+  * only 15 bytes (instead of 18) are available for the URI on nRF8001 based boards/shields, because GAP flags (3 bytes) are in advertisement data
+
+## Using [codebender](https://codebender.cc)
+
+ 1. Open [physical_web_beacon](https://codebender.cc/example/BLEPeripheral/physical_web_beacon) in codebender
+ 1. Update pin outs in sketch based on hardware setup (```URI_BEACON_REQ```, ```URI_BEACON_RDY```, ```URI_BEACON_RST```)
+ 1. If needed, update flags, power and URI parameters to ```uriBeacon.begin``` in sketch
+ 1. Run
+
+
 
 


### PR DESCRIPTION
- adds instructions for using sketch from codebender.cc
- update note that 15 byte URI limit is only for nRF8001 based boards
