### PR TITLE
RFduino firmware: advertise as non-connectable peripheral

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,6 +13,7 @@ devashishmamgain
 dinhviethoa
 don
 g-ortuno
+gbuesing
 grahamoregan
 gshaw
 ianobermiller

--- a/firmware/RFduino/physical_web/physical_web.ino
+++ b/firmware/RFduino/physical_web/physical_web.ino
@@ -23,6 +23,7 @@ void setup() {
   RFduinoBLE_advdata = advdata;
   RFduinoBLE_advdata_len = sizeof(advdata);
   RFduinoBLE.advertisementInterval = 1000; // advertise every 1000ms
+  RFduinoBLE.connectable = false;
   RFduinoBLE.begin();
 }
 


### PR DESCRIPTION
RFduino Arduino library v2.2 supports non-connectable advertisements - relevant commit: https://github.com/RFduino/RFduino/commit/24c9bac899c51563eac324fd62437862f71f080b

This pull request uses this new feature to make the RFduino advertise as non-connectable.

Previously, a device could connect to the RFduino, which would disable advertising. Making device non-connectable ensures that it will advertise as expected.
