### PR TITLE
slow metadata response fix

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
@@ -231,6 +231,7 @@ public class NearbyBeaconsFragment extends ListFragment implements MetadataResol
     mNearbyDeviceAdapter.addItem(url, mockAddress);
     mNearbyDeviceAdapter.updateItem(url, mockAddress, mockRssi, mockTxPower);
     // Inform the list adapter of the new data
+    mNearbyDeviceAdapter.sortDevices();
     mNearbyDeviceAdapter.notifyDataSetChanged();
     // Stop the refresh animation
     mSwipeRefreshWidget.setRefreshing(false);
@@ -464,6 +465,7 @@ public class NearbyBeaconsFragment extends ListFragment implements MetadataResol
     }
 
     public void clear() {
+      mSortedDevices.clear();
       mUrlToDeviceAddress.clear();
       notifyDataSetChanged();
     }

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
@@ -84,6 +84,7 @@ public class NearbyBeaconsFragment extends ListFragment implements MetadataResol
       mScanningAnimationDrawable.stop();
       scanLeDevice(false);
       mMdnsUrlDiscoverer.stopScanning();
+      mNearbyDeviceAdapter.sortDevices();
       mNearbyDeviceAdapter.notifyDataSetChanged();
     }
   };
@@ -211,12 +212,12 @@ public class NearbyBeaconsFragment extends ListFragment implements MetadataResol
   @Override
   public void onUrlMetadataReceived(String url, MetadataResolver.UrlMetadata urlMetadata) {
     mUrlToUrlMetadata.put(url, urlMetadata);
-    mNearbyDeviceAdapter.redrawListView();
+    mNearbyDeviceAdapter.notifyDataSetChanged();
   }
 
   @Override
   public void onUrlMetadataIconReceived() {
-    mNearbyDeviceAdapter.redrawListView();
+    mNearbyDeviceAdapter.notifyDataSetChanged();
   }
 
   @Override
@@ -437,8 +438,6 @@ public class NearbyBeaconsFragment extends ListFragment implements MetadataResol
       else {
         // Clear the children views content (in case this is a recycled list item view)
         titleTextView.setText("");
-        urlTextView.setText("");
-        descriptionTextView.setText("");
         iconImageView.setImageDrawable(null);
         // Set the url text to be the beacon's advertised url
         urlTextView.setText(url);
@@ -459,20 +458,14 @@ public class NearbyBeaconsFragment extends ListFragment implements MetadataResol
       return null;
     }
 
-    @Override
-    public void notifyDataSetChanged() {
+    public void sortDevices() {
       mSortedDevices = new ArrayList<>(mUrlToDeviceAddress.values());
       Collections.sort(mSortedDevices, mComparator);
-      super.notifyDataSetChanged();
     }
 
     public void clear() {
       mUrlToDeviceAddress.clear();
       notifyDataSetChanged();
-    }
-
-    public void redrawListView() {
-      super.notifyDataSetChanged();
     }
   }
 }

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
@@ -411,15 +411,11 @@ public class NearbyBeaconsFragment extends ListFragment implements MetadataResol
         view = getActivity().getLayoutInflater().inflate(R.layout.list_item_nearby_beacon, viewGroup, false);
       }
 
-      // Clear the children views content (in case this is a recycled list item view)
+      // Reference the list item views
       TextView titleTextView = (TextView) view.findViewById(R.id.title);
-      titleTextView.setText("");
       TextView urlTextView = (TextView) view.findViewById(R.id.url);
-      urlTextView.setText("");
       TextView descriptionTextView = (TextView) view.findViewById(R.id.description);
-      descriptionTextView.setText("");
       ImageView iconImageView = (ImageView) view.findViewById(R.id.icon);
-      iconImageView.setImageDrawable(null);
 
       // Get the url for the given position
       String url = getUrlForListItem(i);
@@ -439,6 +435,11 @@ public class NearbyBeaconsFragment extends ListFragment implements MetadataResol
       }
       // If metadata does not yet exist
       else {
+        // Clear the children views content (in case this is a recycled list item view)
+        titleTextView.setText("");
+        urlTextView.setText("");
+        descriptionTextView.setText("");
+        iconImageView.setImageDrawable(null);
         // Set the url text to be the beacon's advertised url
         urlTextView.setText(url);
         // Set the description text to show loading status

--- a/android/PhysicalWeb/app/src/main/res/layout/list_item_nearby_beacon.xml
+++ b/android/PhysicalWeb/app/src/main/res/layout/list_item_nearby_beacon.xml
@@ -70,12 +70,11 @@
                 android:id="@+id/description"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-
                 android:text=""
                 android:textSize="14sp"
                 android:fontFamily="arial-sans-serif"
                 android:textColor="@color/description_color"
-                android:maxLines="3"
+                android:lines="3"
                 android:ellipsize="end"
                 android:lineSpacingExtra="1.5dp">
         </TextView>

--- a/android/PhysicalWeb/app/src/main/res/layout/list_item_nearby_beacon.xml
+++ b/android/PhysicalWeb/app/src/main/res/layout/list_item_nearby_beacon.xml
@@ -74,7 +74,7 @@
                 android:textSize="14sp"
                 android:fontFamily="arial-sans-serif"
                 android:textColor="@color/description_color"
-                android:lines="3"
+                android:lines="2"
                 android:ellipsize="end"
                 android:lineSpacingExtra="1.5dp">
         </TextView>

--- a/android/PhysicalWeb/app/src/main/res/values/strings.xml
+++ b/android/PhysicalWeb/app/src/main/res/values/strings.xml
@@ -38,5 +38,6 @@
     <string name="oob_accept_and_continue">ACCEPT &amp; CONTINUE</string>
     <string name="user_opted_in_flag">userOptedIn</string>
     <string name="physical_web_preference_file_name">physical_web_preferences</string>
+    <string name="metadata_loading">loading...</string>
 
 </resources>


### PR DESCRIPTION
After scan timeout of 3 seconds, list items that do not have metadata
are shown with just the advertised beacon url. As the metadata is
received (after the 3 seconds), the correlate list item ui is updated
to show that metadata. Also, view recycling is now handled so that list
items are always cleared in getView() before updating (since a recycled
view may contain another url’s metadata from a previous cycle)

Please review @g-ortuno 