### PR TITLE
handling no network

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
@@ -217,13 +217,16 @@ public class NearbyBeaconsFragment extends ListFragment implements MetadataResol
     }
     // Get the url for the given item
     String url = mNearbyDeviceAdapter.getUrlForListItem(position);
-    String siteUrl = mUrlToUrlMetadata.get(url).siteUrl;
-    if (siteUrl != null) {
-      // Open the url in the browser
-      openUrlInBrowser(siteUrl);
-    } else {
-      Toast.makeText(getActivity(), "No URL found.", Toast.LENGTH_SHORT).show();
+    String urlToNavigateTo = url;
+    // If this url has metadata
+    if (mUrlToUrlMetadata.get(url) != null) {
+      String siteUrl = mUrlToUrlMetadata.get(url).siteUrl;
+      // If the metadata has a siteUrl
+      if (siteUrl != null) {
+        urlToNavigateTo = siteUrl;
+      }
     }
+    openUrlInBrowser(urlToNavigateTo);
   }
 
   @Override

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UriBeaconDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UriBeaconDiscoveryService.java
@@ -523,12 +523,21 @@ public class UriBeaconDiscoveryService extends Service implements MetadataResolv
   }
 
   private PendingIntent createNavigateToUrlPendingIntent(String url) {
-    if (!URLUtil.isNetworkUrl(url)) {
-      url = "http://" + url;
+    String urlToNavigateTo = url;
+    // If this url has metadata
+    if (mUrlToUrlMetadata.get(url) != null) {
+      String siteUrl = mUrlToUrlMetadata.get(url).siteUrl;
+      // If this metadata has a siteUrl
+      if (siteUrl != null) {
+        urlToNavigateTo = siteUrl;
+      }
     }
-    url = MetadataResolver.createUrlProxyGoLink(url);
+    if (!URLUtil.isNetworkUrl(urlToNavigateTo)) {
+      urlToNavigateTo = "http://" + urlToNavigateTo;
+    }
+    urlToNavigateTo = MetadataResolver.createUrlProxyGoLink(urlToNavigateTo);
     Intent intent = new Intent(Intent.ACTION_VIEW);
-    intent.setData(Uri.parse(url));
+    intent.setData(Uri.parse(urlToNavigateTo));
     int requestID = (int) System.currentTimeMillis();
     PendingIntent pendingIntent = PendingIntent.getActivity(this, requestID, intent, 0);
     return pendingIntent;


### PR DESCRIPTION
If the user taps a url in the list view with no metadata, the browsers
opens to the listed url (instead of the missing siteUrl). The same
metadata check is done for the notifications as well.
Please review @g-ortuno 