### PR TITLE
Make all notifications public on Lollipop

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UriBeaconDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UriBeaconDiscoveryService.java
@@ -100,6 +100,7 @@ public class UriBeaconDiscoveryService extends Service implements MetadataResolv
   private static final int NON_LOLLIPOP_NOTIFICATION_URL_COLOR = Color.parseColor("#999999");
   private static final int NON_LOLLIPOP_NOTIFICATION_SNIPPET_COLOR = Color.parseColor("#999999");
   private static final int NOTIFICATION_PRIORITY = NotificationCompat.PRIORITY_LOW;
+  private static final int NOTIFICATION_VISIBILITY = NotificationCompat.VISIBILITY_PUBLIC;
   private static final long NOTIFICATION_UPDATE_GATE_DURATION = 1000;
   private boolean mCanUpdateNotifications = false;
   private Handler mHandler;
@@ -417,6 +418,9 @@ public class UriBeaconDiscoveryService extends Service implements MetadataResolv
         .setContentText(description)
         .setPriority(NOTIFICATION_PRIORITY)
         .setContentIntent(pendingIntent);
+    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      builder.setVisibility(NOTIFICATION_VISIBILITY);
+    }
     // For some reason if there is only one notification and you call setGroup
     // the notification doesn't show up on the N7 running kit kat
     if (!single) {
@@ -439,15 +443,18 @@ public class UriBeaconDiscoveryService extends Service implements MetadataResolv
     String contentText = getString(R.string.summary_notification_pull_down);
     PendingIntent pendingIntent = createReturnToAppPendingIntent();
     NotificationCompat.Builder builder = new NotificationCompat.Builder(this);
-    Notification notification = builder.setSmallIcon(R.drawable.ic_notification)
+    builder.setSmallIcon(R.drawable.ic_notification)
         .setContentTitle(contentTitle)
         .setContentText(contentText)
         .setSmallIcon(R.drawable.ic_notification)
         .setGroup(NOTIFICATION_GROUP_KEY)
         .setGroupSummary(true)
         .setPriority(NOTIFICATION_PRIORITY)
-        .setContentIntent(pendingIntent)
-        .build();
+        .setContentIntent(pendingIntent);
+    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      builder.setVisibility(NOTIFICATION_VISIBILITY);
+    }
+    Notification notification = builder.build();
 
     // Create the big view for the notification (viewed by pulling down)
     RemoteViews remoteViews = updateSummaryNotificationRemoteViews();


### PR DESCRIPTION
I'm aware that it's requested to file an issue first before creating a commit.  This change was mostly just so I could play with the code so I didn't bother creating an issue.

This was tested on a Nexus 5 running Android 5.1