### PR TITLE
Ensure the discovery service starts at boot

### DIFF
--- a/android/PhysicalWeb/app/src/main/AndroidManifest.xml
+++ b/android/PhysicalWeb/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <!-- This is required for the scan library. -->
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
 
@@ -36,6 +37,13 @@
             android:enabled="true"
             android:exported="false">
         </service>
+
+        <receiver
+            android:name=".AutostartUriBeaconDiscoveryServiceReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
         <!-- This is required for the scan library. -->
         <service

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/AutostartUriBeaconDiscoveryServiceReceiver.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/AutostartUriBeaconDiscoveryServiceReceiver.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.physical_web.physicalweb;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+
+/**
+ * This receiver starts the UriBeaconDiscoveryService
+ */
+public class AutostartUriBeaconDiscoveryServiceReceiver extends BroadcastReceiver {
+  public void onReceive(Context context, Intent intent) {
+    String preferences_key = context.getString(R.string.physical_web_preference_file_name);
+    SharedPreferences sharedPreferences =
+        context.getSharedPreferences(preferences_key, Context.MODE_PRIVATE);
+    if (sharedPreferences.getBoolean(context.getString(R.string.user_opted_in_flag), false)) {
+      Intent newIntent = new Intent(context, UriBeaconDiscoveryService.class);
+      context.startService(newIntent);
+    }
+  }
+}


### PR DESCRIPTION
Previously, a user would have to reopen the application after rebooting
in order to start the discovery service again.  This starts it
automatically if they have opted in.

--------------------------------------------

Tested on a Nexus 5 running 5.1 -- it took a minute or two to trigger from the time the lock screen was first available, but eventually it started noticing beacons without having to start the app at all.