### PR TITLE
Removing the id field from PWS messages

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/MetadataResolver.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/MetadataResolver.java
@@ -181,18 +181,14 @@ class MetadataResolver {
 
                   JSONObject jsonUrlMetadata = foundMetaData.getJSONObject(i);
 
+                  String url = jsonUrlMetadata.getString("url");
                   String title = "";
-                  String url = "";
                   String description = "";
                   String iconUrl = "/favicon.ico";
-                  String id = jsonUrlMetadata.getString("id");
                   float score = UNDEFINED_SCORE;
 
                   if (jsonUrlMetadata.has("title")) {
                     title = jsonUrlMetadata.getString("title");
-                  }
-                  if (jsonUrlMetadata.has("url")) {
-                    url = jsonUrlMetadata.getString("url");
                   }
                   if (jsonUrlMetadata.has("description")) {
                     description = jsonUrlMetadata.getString("description");
@@ -228,9 +224,9 @@ class MetadataResolver {
                   downloadIcon(urlMetadata);
 
                   if (isDemoRequest) {
-                    mMetadataResolverCallback.onDemoUrlMetadataReceived(id, urlMetadata);
+                    mMetadataResolverCallback.onDemoUrlMetadataReceived(url, urlMetadata);
                   } else {
-                    mMetadataResolverCallback.onUrlMetadataReceived(id, urlMetadata);
+                    mMetadataResolverCallback.onUrlMetadataReceived(url, urlMetadata);
                   }
                 }
 

--- a/web-service/helpers.py
+++ b/web-service/helpers.py
@@ -41,7 +41,6 @@ def BuildResponse(objects):
 
         def append_invalid():
             metadata_output.append({
-                'id': url,
                 'url': url
             })
 
@@ -71,7 +70,6 @@ def BuildResponse(objects):
             taskqueue.add(url='/refresh-url', params={'url': url})
 
         device_data = {}
-        device_data['id'] = url
         device_data['url'] = siteInfo.url
         if siteInfo.title is not None:
             device_data['title'] = siteInfo.title


### PR DESCRIPTION
The url field is effectively the id.