### PR TITLE
Removed double spaces in notifications

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UriBeaconDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UriBeaconDiscoveryService.java
@@ -448,7 +448,7 @@ public class UriBeaconDiscoveryService extends Service implements MetadataResolv
    */
   private void updateSummaryNotification() {
     int numNearbyBeacons = mSortedDevices.size();
-    String contentTitle = String.valueOf(numNearbyBeacons) + " ";
+    String contentTitle = String.valueOf(numNearbyBeacons);
     Resources resources = getResources();
     contentTitle += " " + resources.getQuantityString(R.plurals.numFoundBeacons, numNearbyBeacons, numNearbyBeacons);
     String contentText = getString(R.string.summary_notification_pull_down);


### PR DESCRIPTION
`9__Beacons_Nearby` becomes `9_Beacons_Nearby` after applying this patch.