### PR TITLE
Switched url-caster to https

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/MetadataResolver.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/MetadataResolver.java
@@ -45,9 +45,9 @@ import java.util.Collection;
 
 class MetadataResolver {
   private static final String TAG = "MetadataResolver";
-  private static final String METADATA_URL = "http://url-caster.appspot.com/resolve-scan";
-  //private static final String METADATA_URL = "http://url-caster-dev.appspot.com/resolve-scan";
-  private static final String DEMO_METADATA_URL = "http://url-caster.appspot.com/demo";
+  private static final String METADATA_URL = "https://url-caster.appspot.com/resolve-scan";
+  //private static final String METADATA_URL = "https://url-caster-dev.appspot.com/resolve-scan";
+  private static final String DEMO_METADATA_URL = "https://url-caster.appspot.com/demo";
   private static final int UNDEFINED_SCORE = -1;
   private static RequestQueue mRequestQueue;
   private static boolean mIsInitialized = false;

--- a/android/PhysicalWeb/app/src/main/res/values/strings.xml
+++ b/android/PhysicalWeb/app/src/main/res/values/strings.xml
@@ -39,7 +39,7 @@
     <string name="user_opted_in_flag">userOptedIn</string>
     <string name="physical_web_preference_file_name">physical_web_preferences</string>
     <string name="metadata_loading">loading...</string>
-    <string name="proxy_go_link_base_url">http://url-caster.appspot.com/go?url=</string>
+    <string name="proxy_go_link_base_url">https://url-caster.appspot.com/go?url=</string>
     <string name="ranging_debug_tx_power_prefix">tx: </string>
     <string name="ranging_debug_rssi_prefix">rssi: </string>
     <string name="ranging_debug_distance_prefix">distance: </string>

--- a/web-service/app.yaml
+++ b/web-service/app.yaml
@@ -24,20 +24,25 @@ handlers:
 - url: /favicon\.ico
   static_files: favicon.ico
   upload: favicon\.ico
+  secure: always
 
 - url: /webui
   static_files: static/index.html
   upload: static/index\.html
+  secure: always
 
 - url: /webui.raw
   static_files: static/raw.html
   upload: static/index\.html
+  secure: always
 
 - url: /shorten-url
   script: shortener.app
+  secure: always
 
 - url: .*
   script: handlers.app
+  secure: always
 
 libraries:
 - name: webapp2

--- a/web-service/tests.py
+++ b/web-service/tests.py
@@ -21,8 +21,8 @@ import urllib2
 ################################################################################
 
 LOCAL_ENDPOINT = 'http://localhost:8080'
-REMOTE_ENDPOINT = 'http://url-caster.appspot.com'
-REMOTE_DEV_ENDPOINT = 'http://url-caster-dev.appspot.com'
+REMOTE_ENDPOINT = 'https://url-caster.appspot.com'
+REMOTE_DEV_ENDPOINT = 'https://url-caster-dev.appspot.com'
 
 ################################################################################
 


### PR DESCRIPTION
Serving `url-caster.appspot.com` over SSL is cheap and best practise.
Lets' do it.