### PR TITLE
Switch from favicon URLs to dataURI

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
@@ -241,11 +241,6 @@ public class NearbyBeaconsFragment extends ListFragment implements MetadataResol
   }
 
   @Override
-  public void onUrlMetadataIconReceived() {
-    mNearbyDeviceAdapter.notifyDataSetChanged();
-  }
-
-  @Override
   public void onDemoUrlMetadataReceived(String url, MetadataResolver.UrlMetadata urlMetadata) {
     // Update the hash table
     mUrlToUrlMetadata.put(url, urlMetadata);

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UriBeaconDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UriBeaconDiscoveryService.java
@@ -272,11 +272,6 @@ public class UriBeaconDiscoveryService extends Service implements MetadataResolv
   }
 
   @Override
-  public void onUrlMetadataIconReceived() {
-    updateNotifications();
-  }
-
-  @Override
   public void onMdnsUrlFound(String url) {
     onLanUrlFound(url);
   }


### PR DESCRIPTION
Instead of returning favicon URLs that client needs to fetch, PWS now fetches it first and returns base64 encoded dataURIs in metadata.

BUG=#220