### PR TITLE
Read signing configuration from signing.gradle

### DIFF
--- a/android/PhysicalWeb/.gitignore
+++ b/android/PhysicalWeb/.gitignore
@@ -1,5 +1,10 @@
+# Keystore files for signing
+*.jks
+*.keystore
+
 .gradle
-local.properties
 .idea
 .DS_Store
 build
+local.properties
+signing.properties

--- a/android/PhysicalWeb/app/build.gradle
+++ b/android/PhysicalWeb/app/build.gradle
@@ -18,9 +18,30 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
+    }
+
+    if(new File("signing.properties").exists()) {
+        Properties signingProperties = new Properties()
+        signingProperties.load(new FileInputStream(new File('signing.properties')))
+
+        signingConfigs {
+            release {
+                storeFile new File(signingProperties['storeFile'])
+                storePassword signingProperties['storePassword']
+                keyAlias signingProperties['keyAlias']
+                keyPassword signingProperties['keyPassword']
+            }
+        }
+
+        buildTypes {
+            release {
+                signingConfig signingConfigs.release
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Instead of manually pasting configuration values into gradle or
studio on each release, this lets the developer keep a
signing.properties file with the necessary information.