### PR TITLE
[PWS] Added Physical Web User Agent

### DIFF
--- a/web-service/helpers.py
+++ b/web-service/helpers.py
@@ -33,6 +33,7 @@ import lxml.etree
 ################################################################################
 
 ENABLE_EXPERIMENTAL = app_identity.get_application_id().endswith('-dev')
+PHYSICAL_WEB_USER_AGENT = 'Mozilla/5.0 (compatible; PhysicalWeb/1.0; +http://physical-web.org)'
 
 ################################################################################
 
@@ -138,7 +139,7 @@ def GetSiteInfoForUrl(url, distance=None, force_update=False):
 def FetchAndStoreUrl(siteInfo, url, distance=None, force_update=False):
     # Index the page
     try:
-        headers = {}
+        headers = {'User-Agent': PHYSICAL_WEB_USER_AGENT}
         if ENABLE_EXPERIMENTAL and distance is not None:
             headers['X-PhysicalWeb-Distance'] = distance
 


### PR DESCRIPTION
Some websites rely on the "Mozilla5/0" part of the User-Agent string to serve web content. Let's add a Physical Web User Agent to fix that issue.

Moreover, this could lead websites in general to serve specific content (small and fast) for those who examine HTTP Headers User-Agent. What do you think?