### PR TITLE
[PWS] Handle ValueError for JSON for Linking Data

### DIFF
--- a/web-service/helpers.py
+++ b/web-service/helpers.py
@@ -349,7 +349,7 @@ def StoreUrl(siteInfo, url, content, encoding):
         jsonldobject = None
         try:
             jsonldobject = json.loads(jsonldtext) # Data is not sanitised.
-        except UnicodeDecodeError:
+        except (ValueError, UnicodeDecodeError):
             jsonldobject = None
         if jsonldobject is not None:
             jsonlds.append(jsonldobject)


### PR DESCRIPTION
Try resolving a page that contains invalid JSON-LD data such as below (taken from orange.fr):
```
		<script type="application/ld+json">
			{
				"@context" : "http://schema.org", [^]
				"@type" : "Organization",
				"name" : "Orange",
				"url" : "http://www.orange.fr", [^]
				"contactPoint" : [
						{
								"@type" : "ContactPoint",
								"telephone" : "+33 8 90 71 01 13",
								"contactType" : "service client",
								"availableLanguage" : "French",
								"areaServed" : "FR"
						}
				]
		}
	</script>
```
This patch adds ValueError Exception Handling so that it fails gracefully.