### PR TITLE
[PWS] Fixed encoding on title and description metadata

### DIFF
--- a/web-service/helpers.py
+++ b/web-service/helpers.py
@@ -250,7 +250,7 @@ def StoreUrl(siteInfo, url, content, encoding):
         if (len(value) > 0):
             title = value[0]
     if title is not None:
-        title = FlattenString(title)
+        title = FlattenString(title.encode(encoding))
 
     # Try to use <meta name="description" content="...">.
     value = htmltree.xpath("//head//meta[@name='description']/attribute::content")
@@ -291,7 +291,7 @@ def StoreUrl(siteInfo, url, content, encoding):
 
     # Cleanup.
     if description is not None:
-        description = FlattenString(description)
+        description = FlattenString(description.encode(encoding))
         if len(description) > 500:
             description = description[:500]
 


### PR DESCRIPTION
Go to http://url-caster-fr.appspot.com/webui and enter "http://www.blackanddecker.fr/".
Before:
```
{
  "metadata": [
    {
      "description": "BLACK+DECKERâ¢ est le premier fournisseur mondial d'outils Ã©lectriques et d'accessoires.",
      "url": "http://www.blackanddecker.fr/",
      "rank": 1000,
      "icon": "http://www.blackanddecker.fr/favicon.ico",
      "title": "Outils Ã©lectriques & Outils de jardin â BLACK+DECKERâ¢",
      "id": "http://www.blackanddecker.fr/"
    }
  ]
}
```
After:
```
{
  "metadata": [
    {
      "description": "BLACK+DECKER™ est le premier fournisseur mondial d'outils électriques et d'accessoires.",
      "url": "http://www.blackanddecker.fr/",
      "rank": 1000,
      "icon": "http://www.blackanddecker.fr/favicon.ico",
      "title": "Outils électriques & Outils de jardin – BLACK+DECKER™",
      "id": "http://www.blackanddecker.fr/"
    }
  ]
}
```