### PR TITLE
Fix android crash by ensuring Nsd listener liveness when stopping discovery

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/MdnsUrlDiscoverer.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/MdnsUrlDiscoverer.java
@@ -54,13 +54,23 @@ class MdnsUrlDiscoverer {
     @Override
     public void onStartDiscoveryFailed(String serviceType, int errorCode) {
       Log.e(TAG, "Discovery failed: Error code:" + errorCode);
-      mNsdManager.stopServiceDiscovery(this);
+      if (this != null) {
+        try {
+          mNsdManager.stopServiceDiscovery(this);
+        } finally {
+        }
+      }
     }
 
     @Override
     public void onStopDiscoveryFailed(String serviceType, int errorCode) {
       Log.e(TAG, "Discovery failed: Error code:" + errorCode);
-      mNsdManager.stopServiceDiscovery(this);
+      if (this != null) {
+        try {
+          mNsdManager.stopServiceDiscovery(this);
+        } finally {
+        }
+      }
     }
   };
   private static final String MDNS_SERVICE_TYPE = "_http._tcp.";


### PR DESCRIPTION
Calling `mNsdManager.stopServiceDiscovery(null);` raises an exception and crashes the android app. Let's check first `mDiscoveryListener` is not null. 