### PR TITLE
Fix #365: Don't run experimental tests when server not in dev mode

### DIFF
--- a/web-service/README.md
+++ b/web-service/README.md
@@ -90,6 +90,5 @@ Physical Web Service, you can change the endpoint by modifying:
 1. Make sure you have created config.SECRET.json from the config.SAMPLE.json
    file.
 2. Install nose `pip install nose`
-2. Install pyyaml `pip install pyyaml`
 3. Run ./tests.py -h to see help
 4. Run ./tests.py to test the development server

--- a/web-service/README.md
+++ b/web-service/README.md
@@ -90,5 +90,6 @@ Physical Web Service, you can change the endpoint by modifying:
 1. Make sure you have created config.SECRET.json from the config.SAMPLE.json
    file.
 2. Install nose `pip install nose`
+2. Install pyyaml `pip install pyyaml`
 3. Run ./tests.py -h to see help
 4. Run ./tests.py to test the development server

--- a/web-service/tests.py
+++ b/web-service/tests.py
@@ -22,9 +22,13 @@ import subprocess
 import unittest
 import urllib
 import urllib2
-
+import yaml
 
 LOCAL_TEST_PORT = 9002
+
+def GetAppSettings():
+    with open('app.yaml', 'r') as f:
+        return yaml.load(f)
 
 
 class PwsTest(unittest.TestCase):
@@ -150,6 +154,10 @@ class TestResolveScan(PwsTest):
                          'https://github.com/Google/physical-web')
 
     def test_redirect_with_rssi_tx_power(self):
+        settings = GetAppSettings()
+        if not settings['application'].endswith('-dev'):
+            return
+
         result = self.call({
             'objects': [
                 {


### PR DESCRIPTION
We may want to clean up tests if ever there are more experimental-only features.  But I think there is nothing to warrent that just yet.