### PR TITLE
This PR adds support for "unresolved" return key from resolve-url

### DIFF
--- a/web-service/handlers.py
+++ b/web-service/handlers.py
@@ -62,10 +62,8 @@ class ResolveScan(webapp2.RequestHandler):
         except:
             objects = []
 
-        metadata_output = helpers.BuildResponse(objects)
-        output = {
-          'metadata': metadata_output
-        }
+        output = helpers.BuildResponse(objects)
+
         self.response.headers['Content-Type'] = 'application/json'
         json_data = json.dumps(output);
         self.response.write(json_data)
@@ -80,10 +78,8 @@ class DemoMetadata(webapp2.RequestHandler):
             {'url': 'http://en.wikipedia.org/wiki/Le_D%C3%A9jeuner_sur_l%E2%80%99herbe'},
             {'url': 'http://sfmoma.org'}
         ]
-        metadata_output = helpers.BuildResponse(objects)
-        output = {
-          'metadata': metadata_output
-        }
+        output = helpers.BuildResponse(objects)
+
         self.response.headers['Content-Type'] = 'application/json'
         json_data = json.dumps(output);
         self.response.write(json_data)

--- a/web-service/helpers.py
+++ b/web-service/helpers.py
@@ -170,7 +170,6 @@ def FetchAndStoreUrl(siteInfo, url, distance=None, force_update=False):
         # TODO: Use the cache-content headers for storeUrl!
         return StoreUrl(siteInfo, url, result.content, encoding)
     elif result.status_code == 204: # No Content
-        # TODO: What do we return?  we want to filter this result out
         return None
     elif result.status_code in [301, 302, 303, 307, 308]: # Moved Permanently, Found, See Other, Temporary Redirect, Permanent Redirect
         final_url = result.headers['location']
@@ -180,6 +179,8 @@ def FetchAndStoreUrl(siteInfo, url, distance=None, force_update=False):
             siteInfo.key.delete()
         # TODO: Most redirects should not be cached, but we should still check!
         return GetSiteInfoForUrl(final_url, distance, force_update)
+    elif 500 <= result.status_code <= 599:
+        return None
     else:
         raise FailedFetchException()
 

--- a/web-service/tests.py
+++ b/web-service/tests.py
@@ -98,6 +98,7 @@ class TestResolveScan(PwsTest):
         })
         self.assertIn('metadata', result)
         self.assertEqual(len(result['metadata']), 0)
+        self.assertEqual(len(result['unresolved']), 1)
 
 
     def test_rssi_ranking(self):


### PR DESCRIPTION
For urls which we could not look up (i.e. 404 errors), we add them
to the list of unresolved.

This is distinct from urls which we could fetch, but filtered out of
results (i.e. 500 errors, 204 No Data)..