### PR TITLE
[PWS] Fixed encoding on title and description metadata [Take 2]

### DIFF
--- a/web-service/helpers.py
+++ b/web-service/helpers.py
@@ -172,6 +172,13 @@ def FetchAndStoreUrl(siteInfo, url, distance=None, force_update=False):
 ################################################################################
 
 def GetContentEncoding(content):
+    try:
+        # Don't assume server return proper charset and always try UTF-8 first.
+        u_value = unicode(content, 'utf-8')
+        return 'utf-8'
+    except UnicodeDecodeError:
+        pass
+
     encoding = None
     parser = lxml.etree.HTMLParser(encoding='iso-8859-1')
     htmltree = lxml.etree.fromstring(content, parser)
@@ -189,12 +196,8 @@ def GetContentEncoding(content):
             encoding = value[0]
 
     if encoding is None:
-        try:
-            encoding = 'utf-8'
-            u_value = unicode(content, 'utf-8')
-        except UnicodeDecodeError:
-            encoding = 'iso-8859-1'
-            u_value = unicode(content, 'iso-8859-1')
+        encoding = 'iso-8859-1'
+        u_value = unicode(content, 'iso-8859-1')
 
     return encoding
 


### PR DESCRIPTION
Go to http://url-caster-fr.appspot.com/webui and enter "http://www.blackanddecker.fr/".
Before:
```
{
  "metadata": [
    {
      "description": "BLACK+DECKERâ¢ est le premier fournisseur mondial d'outils Ã©lectriques et d'accessoires.",
      "url": "http://www.blackanddecker.fr/",
      "rank": 1000,
      "icon": "http://www.blackanddecker.fr/favicon.ico",
      "title": "Outils Ã©lectriques & Outils de jardin â BLACK+DECKERâ¢",
      "id": "http://www.blackanddecker.fr/"
    }
  ]
}
```
After:
```
{
  "metadata": [
    {
      "description": "BLACK+DECKER™ est le premier fournisseur mondial d'outils électriques et d'accessoires.",
      "url": "http://www.blackanddecker.fr/",
      "rank": 1000,
      "icon": "http://www.blackanddecker.fr/favicon.ico",
      "title": "Outils électriques & Outils de jardin – BLACK+DECKER™",
      "id": "http://www.blackanddecker.fr/"
    }
  ]
}
```

BUG=#382