### PR TITLE
Let out favicon contentType check

### DIFF
--- a/web-service/helpers.py
+++ b/web-service/helpers.py
@@ -355,7 +355,8 @@ def StoreUrl(siteInfo, url, content, encoding):
             contentType = result.headers['Content-Type']
             if contentType is None:
                 icon = None
-            elif not contentType.startswith('image/'):
+            elif (contentType != 'application/octet-stream' and
+                  not contentType.startswith('image/')):
                 icon = None
     except:
         s_url = url

--- a/web-service/tests.py
+++ b/web-service/tests.py
@@ -207,7 +207,7 @@ class TestResolveScan(PwsTest):
             self.assertIn('url', beaconResult)
             self.assertIn('rank', beaconResult)
             self.assertIn('id', beaconResult)
-            #self.assertIn('icon', beaconResult)
+            self.assertIn('icon', beaconResult)
 
     def test_invalid_rssi(self):
         result = self.call({


### PR DESCRIPTION
Rather than restricting favicons strictly to `image/` contentType, let's add `application/octet-stream` so that it works on more websites.
Once again, http://www.orange.fr was failing...