### PR TITLE
add other node.js examples

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -30,6 +30,9 @@ The basic scanner uses [node-uri-beacon-scanner](https://github.com/sandeepmistr
 
 Then prints out the URI, flags, TX power and RSSI for each discovered beacon.
 
+### Other examples
+
+* [Physical Web Scan](https://github.com/dermike/physical-web-scan) - using the PW proxy to display metadata
 
 ## More information
 

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -30,7 +30,7 @@ The basic scanner uses [node-uri-beacon-scanner](https://github.com/sandeepmistr
 
 Then prints out the URI, flags, TX power and RSSI for each discovered beacon.
 
-### Other examples
+## Other examples
 
 * [Physical Web Scan](https://github.com/dermike/physical-web-scan) - using the PW proxy to display metadata
 


### PR DESCRIPTION
Adding other examples heading to collect more examples of using node.js to scan for uribeacons, including an alternative example that also displays metadata using the PW proxy server.