### PR TITLE
add README's for iOS and Android clients with download links

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,5 @@
+# Android client
+
+This Android client can be downloaded from the [Google Play store](https://play.google.com/store/apps/details?id=physical_web.org.physicalweb). A walkthrough of the app [is here](http://github.com/google/physical-web/blob/master/documentation/android_client_walkthrough.md) and will show you how to put your URL into a beacon.
+
+Keep in mind that this software is just a prototype. We are doing it this way to easily and quickly test the concept. Eventually, the goal is to have this Physical Web code rolled into each browser.

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,5 @@
+# iOS client
+
+This iOS client can be downloaded from the [Apple App Store](https://itunes.apple.com/us/app/physical-web/id927653608?mt=8). A walkthrough of the app [is here](http://github.com/google/physical-web/blob/master/documentation/android_client_walkthrough.md) (Android version) and will show you how to put your URL into a beacon.
+
+Keep in mind that this software is just a prototype. We are doing it this way to easily and quickly test the concept. Eventually, the goal is to have this Physical Web code rolled into each browser.


### PR DESCRIPTION
Adding README's with links to download respective iOS and Android clients. This makes them easier to find when navigating from the main README client links.