### PR TITLE
[android] Use setServiceUuid to build scan filter

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UriBeaconDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UriBeaconDiscoveryService.java
@@ -270,14 +270,10 @@ public class UriBeaconDiscoveryService extends Service
 
     List<ScanFilter> filters = new ArrayList<>();
     filters.add(new ScanFilter.Builder()
-        .setServiceData(UriBeacon.URI_SERVICE_UUID,
-            new byte[]{},
-            new byte[]{})
+        .setServiceUuid(UriBeacon.URI_SERVICE_UUID)
         .build());
     filters.add(new ScanFilter.Builder()
-        .setServiceData(UriBeacon.TEST_SERVICE_UUID,
-            new byte[]{},
-            new byte[]{})
+        .setServiceUuid(UriBeacon.TEST_SERVICE_UUID)
         .build());
 
     boolean started = getLeScanner().startScan(filters, settings, mScanCallback);


### PR DESCRIPTION
Not only is this simpler, but this ensures that other mask values, etc.
are set to null and not an empty byte array.  This ensures that all the
appropriate beacons show up and fixes a bug that hid some in the
surfaced notifications.