### PR TITLE
[android] Rename UriBeacon Service to Pwo Service

### DIFF
--- a/android/PhysicalWeb/app/src/main/AndroidManifest.xml
+++ b/android/PhysicalWeb/app/src/main/AndroidManifest.xml
@@ -33,13 +33,13 @@
         </activity>
 
         <service
-            android:name=".UriBeaconDiscoveryService"
+            android:name=".PwoDiscoveryService"
             android:enabled="true"
             android:exported="false">
         </service>
 
         <receiver
-            android:name=".AutostartUriBeaconDiscoveryServiceReceiver">
+            android:name=".AutostartPwoDiscoveryServiceReceiver">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/AutostartPwoDiscoveryServiceReceiver.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/AutostartPwoDiscoveryServiceReceiver.java
@@ -24,13 +24,13 @@ import android.content.SharedPreferences;
 /**
  * This receiver starts the UriBeaconDiscoveryService
  */
-public class AutostartUriBeaconDiscoveryServiceReceiver extends BroadcastReceiver {
+public class AutostartPwoDiscoveryServiceReceiver extends BroadcastReceiver {
   public void onReceive(Context context, Intent intent) {
     String preferences_key = context.getString(R.string.physical_web_preference_file_name);
     SharedPreferences sharedPreferences =
         context.getSharedPreferences(preferences_key, Context.MODE_PRIVATE);
     if (sharedPreferences.getBoolean(context.getString(R.string.user_opted_in_flag), false)) {
-      Intent newIntent = new Intent(context, UriBeaconDiscoveryService.class);
+      Intent newIntent = new Intent(context, PwoDiscoveryService.class);
       context.startService(newIntent);
     }
   }

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/MainActivity.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/MainActivity.java
@@ -119,7 +119,7 @@ public class MainActivity extends Activity {
    * Stop the beacon discovery service from running.
    */
   private void stopUriBeaconDiscoveryService() {
-    Intent intent = new Intent(this, UriBeaconDiscoveryService.class);
+    Intent intent = new Intent(this, PwoDiscoveryService.class);
     stopService(intent);
   }
 
@@ -127,7 +127,7 @@ public class MainActivity extends Activity {
    * Start up the BeaconDiscoveryService
    */
   private void startUriBeaconDiscoveryService() {
-    Intent intent = new Intent(this, UriBeaconDiscoveryService.class);
+    Intent intent = new Intent(this, PwoDiscoveryService.class);
     startService(intent);
   }
 

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
@@ -59,7 +59,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
- * This is a service that scans for nearby uriBeacons.
+ * This is a service that scans for nearby Physical Web Objects.
  * It is created by MainActivity.
  * It finds nearby ble beacons,
  * and stores a count of them.
@@ -72,12 +72,12 @@ import java.util.concurrent.TimeUnit;
  * the current number of nearby beacons.
  */
 
-public class UriBeaconDiscoveryService extends Service
-                                       implements PwsClient.ResolveScanCallback,
-                                                  MdnsUrlDiscoverer.MdnsUrlDiscovererCallback,
-                                                  SsdpUrlDiscoverer.SsdpUrlDiscovererCallback {
+public class PwoDiscoveryService extends Service
+                                 implements PwsClient.ResolveScanCallback,
+                                            MdnsUrlDiscoverer.MdnsUrlDiscovererCallback,
+                                            SsdpUrlDiscoverer.SsdpUrlDiscovererCallback {
 
-  private static final String TAG = "UriBeaconDiscoveryService";
+  private static final String TAG = "PwoDiscoveryService";
   private final ScanCallback mScanCallback = new ScanCallback() {
     @Override
     public void onScanResult(int callbackType, ScanResult scanResult) {
@@ -130,7 +130,7 @@ public class UriBeaconDiscoveryService extends Service
     }
   };
 
-  public UriBeaconDiscoveryService() {
+  public PwoDiscoveryService() {
   }
 
   private static String generateMockBluetoothAddress(int hashCode) {
@@ -144,8 +144,8 @@ public class UriBeaconDiscoveryService extends Service
 
   private void initialize() {
     mNotificationManager = NotificationManagerCompat.from(this);
-    mMdnsUrlDiscoverer = new MdnsUrlDiscoverer(this, UriBeaconDiscoveryService.this);
-    mSsdpUrlDiscoverer = new SsdpUrlDiscoverer(this, UriBeaconDiscoveryService.this);
+    mMdnsUrlDiscoverer = new MdnsUrlDiscoverer(this, this);
+    mSsdpUrlDiscoverer = new SsdpUrlDiscoverer(this, this);
     mHandler = new Handler();
     initializeScreenStateBroadcastReceiver();
   }
@@ -244,8 +244,7 @@ public class UriBeaconDiscoveryService extends Service
       pwoMetadata.isPublic = false;
       mDeviceAddressToUrl.put(mockAddress, url);
       mRegionResolver.onUpdate(mockAddress, mockRssi, mockTxPower);
-      PwsClient.getInstance(this).findUrlMetadata(url, mockTxPower, mockRssi,
-                                                  UriBeaconDiscoveryService.this, TAG);
+      PwsClient.getInstance(this).findUrlMetadata(url, mockTxPower, mockRssi, this, TAG);
     }
   }
 
@@ -304,8 +303,7 @@ public class UriBeaconDiscoveryService extends Service
             pwoMetadata.setBleMetadata(deviceAddress, rssi, txPower);
             mDeviceAddressToUrl.put(deviceAddress, url);
             // Fetch the metadata for this url
-            PwsClient.getInstance(this).findUrlMetadata(url, txPower, rssi,
-                                                        UriBeaconDiscoveryService.this, TAG);
+            PwsClient.getInstance(this).findUrlMetadata(url, txPower, rssi, this, TAG);
           }
           // Update the ranging data
           mRegionResolver.onUpdate(deviceAddress, rssi, txPower);


### PR DESCRIPTION
UriBeaconDiscoveryService -> PwoDiscoveryService
There's several reasons to rename this class, but we are already
finding non-uribeacon PWOs (i.e. via MDNS, SSDP).