### PR TITLE
[android] Use PwoMetadata as request object

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
@@ -203,14 +203,12 @@ public class NearbyBeaconsFragment extends ListFragment
   }
 
   @Override
-  public void onUrlMetadataReceived(String url, UrlMetadata urlMetadata,
-                                    long tripMillis) {
-    mUrlToPwoMetadata.get(url).setUrlMetadata(urlMetadata, tripMillis);
+  public void onUrlMetadataReceived(PwoMetadata pwoMetadata) {
     mNearbyDeviceAdapter.notifyDataSetChanged();
   }
 
   @Override
-  public void onUrlMetadataIconReceived() {
+  public void onUrlMetadataIconReceived(PwoMetadata pwoMetadata) {
     mNearbyDeviceAdapter.notifyDataSetChanged();
   }
 
@@ -280,8 +278,7 @@ public class NearbyBeaconsFragment extends ListFragment
     if (!mUrlToPwoMetadata.containsKey(url)) {
       PwoMetadata pwoMetadata = addPwoMetadata(url);
       // Fetch the metadata for the given url
-      PwsClient.getInstance(getActivity()).findUrlMetadata(url, 0, 0, NearbyBeaconsFragment.this,
-                                                           TAG);
+      PwsClient.getInstance(getActivity()).findUrlMetadata(pwoMetadata, this, TAG);
       mNearbyDeviceAdapter.addItem(pwoMetadata);
     }
   }
@@ -314,8 +311,8 @@ public class NearbyBeaconsFragment extends ListFragment
                   pwoMetadata.setBleMetadata(deviceAddress, rssi, txPower);
                   mNearbyDeviceAdapter.addItem(pwoMetadata);
                   // Fetch the metadata for this url
-                  PwsClient.getInstance(getActivity()).findUrlMetadata(
-                      url, txPower, rssi, NearbyBeaconsFragment.this, TAG);
+                  PwsClient.getInstance(getActivity()).findUrlMetadata(pwoMetadata,
+                      NearbyBeaconsFragment.this, TAG);
                 }
                 // Tell the adapter to update stored data for this url
                 mNearbyDeviceAdapter.updateItem(url, deviceAddress, rssi, txPower);

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
@@ -197,17 +197,12 @@ public class PwoDiscoveryService extends Service
   }
 
   @Override
-  public void onUrlMetadataReceived(String url, UrlMetadata urlMetadata,
-                                    long tripMillis) {
-    PwoMetadata pwoMetadata = mUrlToPwoMetadata.get(url);
-    if (pwoMetadata != null) {
-      pwoMetadata.setUrlMetadata(urlMetadata, tripMillis);
-      updateNotifications();
-    }
+  public void onUrlMetadataReceived(PwoMetadata pwoMetadata) {
+    updateNotifications();
   }
 
   @Override
-  public void onUrlMetadataIconReceived() {
+  public void onUrlMetadataIconReceived(PwoMetadata pwoMetadata) {
     updateNotifications();
   }
 
@@ -225,7 +220,7 @@ public class PwoDiscoveryService extends Service
     if (!mUrlToPwoMetadata.containsKey(url)) {
       PwoMetadata pwoMetadata = addPwoMetadata(url);
       pwoMetadata.isPublic = false;
-      PwsClient.getInstance(this).findUrlMetadata(url, 0, 0, this, TAG);
+      PwsClient.getInstance(this).findUrlMetadata(pwoMetadata, this, TAG);
     }
   }
 
@@ -283,7 +278,7 @@ public class PwoDiscoveryService extends Service
             PwoMetadata pwoMetadata = addPwoMetadata(url);
             pwoMetadata.setBleMetadata(deviceAddress, rssi, txPower);
             // Fetch the metadata for this url
-            PwsClient.getInstance(this).findUrlMetadata(url, txPower, rssi, this, TAG);
+            PwsClient.getInstance(this).findUrlMetadata(pwoMetadata, this, TAG);
           }
           // Update the ranging data
           mRegionResolver.onUpdate(deviceAddress, rssi, txPower);


### PR DESCRIPTION
Instead of passing multiple attributes to PwsClient, this change gives
it a single PwoMetadata object.  This will especially simplify things
if we eventually decide to send more data up to PWS.