### PR TITLE
[android] Update UI when emptying metadata queue

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
@@ -286,6 +286,7 @@ public class NearbyBeaconsFragment extends ListFragment
       mNearbyDeviceAdapter.addItem(pwoMetadata);
     }
     mPwoMetadataQueue.clear();
+    mNearbyDeviceAdapter.notifyDataSetChanged();
   }
 
   private void fadeInListView() {


### PR DESCRIPTION
The whole intend of queueing up metadata before emptying into in the
adapter is so that we can control when the information is displayed.

This fixes issue #445