### PR TITLE
[android] Enforce http(s) only on BLE beacons discovered.

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/BlePwoDiscoverer.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/BlePwoDiscoverer.java
@@ -22,6 +22,7 @@ import android.bluetooth.BluetoothManager;
 import android.content.Context;
 import android.os.ParcelUuid;
 import android.os.Parcelable;
+import android.webkit.URLUtil;
 
 import org.uribeacon.beacon.UriBeacon;
 import org.uribeacon.scan.compat.ScanRecord;
@@ -68,7 +69,7 @@ class BlePwoDiscoverer extends PwoDiscoverer implements BluetoothAdapter.LeScanC
     }
 
     String url = uriBeacon.getUriString();
-    if (url == null || url.isEmpty()) {
+    if (!URLUtil.isNetworkUrl(url)) {
       return;
     }
 


### PR DESCRIPTION
This commit uses the same `URLUtil.isNetworkUrl()` logic as the rest of the application to ensure that only `http` and `https` prefixed UriBeacons are listed in the nearby list, per the discussion in issue https://github.com/google/physical-web/issues/445.

This check replaces the null/empty check, because `isNetworkUtil()` does that for us also.

