### PR TITLE
[android] Refresh without killing DiscoveryService

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
@@ -425,9 +425,12 @@ public class PwoDiscoveryService extends Service
     return pendingIntent;
   }
 
-  public void requestPwoMetadata(PwoResponseCallback pwoResponseCallback) {
-    for (PwoMetadata pwoMetadata : mUrlToPwoMetadata.values()) {
-      pwoResponseCallback.onPwoDiscovered(pwoMetadata);
+  public void requestPwoMetadata(PwoResponseCallback pwoResponseCallback,
+                                 boolean requestCachedPwos) {
+    if (requestCachedPwos) {
+      for (PwoMetadata pwoMetadata : mUrlToPwoMetadata.values()) {
+        pwoResponseCallback.onPwoDiscovered(pwoMetadata);
+      }
     }
     mPwoResponseCallbacks.add(pwoResponseCallback);
   }


### PR DESCRIPTION
This change will also prepare us for when the service chaches
PwoMetadata objects because at that point merely killing the
service won't be enough to force a refresh.