### PR TITLE
[android] Require explicit call to DL favicon

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/BeaconConfigFragment.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/BeaconConfigFragment.java
@@ -240,10 +240,6 @@ public class BeaconConfigFragment extends Fragment implements TextView.OnEditorA
       public void onUrlMetadataAbsent(PwoMetadata pwoMetadata){
         setEditCardUrl(url);
       }
-
-      @Override
-      public void onUrlMetadataIconReceived(PwoMetadata pwoMetadata) {
-      }
     };
     PwoMetadata pwoMetadata = new PwoMetadata(url, 0);
     PwsClient.getInstance(getActivity()).findUrlMetadata(pwoMetadata, resolveScanCallback, TAG);

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
@@ -273,6 +273,10 @@ public class NearbyBeaconsFragment extends ListFragment
     mNearbyDeviceAdapter.notifyDataSetChanged();
   }
 
+  @Override
+  public void onUrlMetadataIconError(PwoMetadata pwoMetadata) {
+  }
+
   private void stopScanningDisplay() {
     // Cancel the scan timeout callback if still active or else it may fire later.
     mHandler.removeCallbacks(mFirstScanTimeout);

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
@@ -61,6 +61,7 @@ import java.util.concurrent.TimeUnit;
 
 public class PwoDiscoveryService extends Service
                                  implements PwsClient.ResolveScanCallback,
+                                            PwsClient.DownloadIconCallback,
                                             PwoDiscoverer.PwoDiscoveryCallback {
 
   private static final String TAG = "PwoDiscoveryService";
@@ -124,7 +125,8 @@ public class PwoDiscoveryService extends Service
    * Callback for subscribers to this service.
    */
   public interface PwoResponseCallback extends PwoDiscoverer.PwoDiscoveryCallback,
-                                               PwsClient.ResolveScanCallback {
+                                               PwsClient.ResolveScanCallback,
+                                               PwsClient.DownloadIconCallback {
   }
 
   public PwoDiscoveryService() {
@@ -193,6 +195,9 @@ public class PwoDiscoveryService extends Service
     for (PwoResponseCallback pwoResponseCallback : mPwoResponseCallbacks) {
       pwoResponseCallback.onUrlMetadataReceived(pwoMetadata);
     }
+    if (!pwoMetadata.urlMetadata.iconUrl.isEmpty()) {
+      PwsClient.getInstance(this).downloadIcon(pwoMetadata, this);
+    }
     updateNotifications();
   }
 
@@ -209,6 +214,13 @@ public class PwoDiscoveryService extends Service
       pwoResponseCallback.onUrlMetadataIconReceived(pwoMetadata);
     }
     updateNotifications();
+  }
+
+  @Override
+  public void onUrlMetadataIconError(PwoMetadata pwoMetadata) {
+    for (PwoResponseCallback pwoResponseCallback : mPwoResponseCallbacks) {
+      pwoResponseCallback.onUrlMetadataIconError(pwoMetadata);
+    }
   }
 
   @Override


### PR DESCRIPTION
This is desirable for three reasons:

1. These are independent features of the PWS, the calls should be made
   distinct
2. The BeaconConfigFragment doesn't use the icon, so we shouldn't
   download it
3. When we start caching PWOs in the discovery service, we'll need to
   fetch icons if we already have the url metadata, but no icon.