### PR TITLE
[android] Returned stored PwoMetadata to clients

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
@@ -213,18 +213,20 @@ public class PwoDiscoveryService extends Service
 
   @Override
   public void onPwoDiscovered(PwoMetadata pwoMetadata) {
+    PwoMetadata storedPwoMetadata = mUrlToPwoMetadata.get(pwoMetadata.url);
+    if (storedPwoMetadata == null) {
+      mUrlToPwoMetadata.put(pwoMetadata.url, pwoMetadata);
+      PwsClient.getInstance(this).findUrlMetadata(pwoMetadata, this, TAG);
+      storedPwoMetadata = pwoMetadata;
+    }
+
     for (PwoResponseCallback pwoResponseCallback : mPwoResponseCallbacks) {
-      pwoResponseCallback.onPwoDiscovered(pwoMetadata);
+      pwoResponseCallback.onPwoDiscovered(storedPwoMetadata);
     }
 
     if (pwoMetadata.hasBleMetadata()) {
       BleMetadata bleMetadata = pwoMetadata.bleMetadata;
       mRegionResolver.onUpdate(bleMetadata.deviceAddress, bleMetadata.rssi, bleMetadata.txPower);
-    }
-
-    if (!mUrlToPwoMetadata.containsKey(pwoMetadata.url)) {
-      mUrlToPwoMetadata.put(pwoMetadata.url, pwoMetadata);
-      PwsClient.getInstance(this).findUrlMetadata(pwoMetadata, this, TAG);
     }
   }
 


### PR DESCRIPTION
Currently, when the Fragment refreshes, we hand it newly discovered
PwoMetadata objects.  However, because the service (typically) already
has the UrlMetadata and the icon, this can prevent the fragment from
being subscribed to the UrlMetadata on refresh.  Instead of giving the
client the newly discovered PwoMetadata objects, we give it the stored
one that matches the url of the newly discovered one.