### PR TITLE
[android] Do not fetch urlMetadata in fragment

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
@@ -330,7 +330,6 @@ public class NearbyBeaconsFragment extends ListFragment
 
     if (!mUrlToPwoMetadata.containsKey(pwoMetadata.url)) {
       mUrlToPwoMetadata.put(pwoMetadata.url, pwoMetadata);
-      PwsClient.getInstance(getActivity()).findUrlMetadata(pwoMetadata, this, TAG);
       mPwoMetadataQueue.add(pwoMetadata);
       if (mSecondScanComplete) {
         // If we've already waited for the second scan timeout, go ahead and put the item in the


### PR DESCRIPTION
The service is supposed to be handling this.  Additionally, it creates
warring fetches that end up confusing things and images don't download.