### PR TITLE
[android] Persist PwoMetadata after service death

### DIFF
--- a/android/PhysicalWeb/app/src/main/res/values/strings.xml
+++ b/android/PhysicalWeb/app/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="oob_accept_and_continue">ACCEPT &amp; CONTINUE</string>
     <string name="user_opted_in_flag">userOptedIn</string>
     <string name="main_prefs_key">org.physical_web.physicalweb.MAIN_PREFS</string>
+    <string name="discovery_service_prefs_key">org.physical_web.physicalweb.DISCOVERY_SERVICE_PREFS</string>
     <string name="metadata_loading">loading&#8230;</string>
     <string name="proxy_go_link_base_url">https://url-caster.appspot.com/go?url=</string>
     <string name="ranging_debug_tx_power_prefix">tx: </string>


### PR DESCRIPTION
This change keeps around some PwoMetadata so that if a user opens the
app sometime after the service dies, it can still start quickly.