### PR TITLE
[android] Use a scoped preference file name

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/AutostartPwoDiscoveryServiceReceiver.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/AutostartPwoDiscoveryServiceReceiver.java
@@ -27,7 +27,7 @@ import android.content.SharedPreferences;
 public class AutostartPwoDiscoveryServiceReceiver extends BroadcastReceiver {
   public void onReceive(Context context, Intent intent) {
     // Make sure the user has opted in
-    String preferencesKey = context.getString(R.string.physical_web_preference_file_name);
+    String preferencesKey = context.getString(R.string.main_prefs_key);
     SharedPreferences sharedPreferences =
         context.getSharedPreferences(preferencesKey, Context.MODE_PRIVATE);
     if (!sharedPreferences.getBoolean(context.getString(R.string.user_opted_in_flag), false)) {

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/MainActivity.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/MainActivity.java
@@ -154,7 +154,8 @@ public class MainActivity extends Activity {
   }
 
   private boolean checkIfUserHasOptedIn() {
-    SharedPreferences sharedPreferences = getSharedPreferences("physical_web_preferences",
+    String preferencesKey = getString(R.string.main_prefs_key);
+    SharedPreferences sharedPreferences = getSharedPreferences(preferencesKey,
                                                                Context.MODE_PRIVATE);
     return sharedPreferences.getBoolean(getString(R.string.user_opted_in_flag), false);
   }

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/OobActivity.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/OobActivity.java
@@ -37,8 +37,9 @@ public class OobActivity extends AppCompatActivity {
     @Override
     public void onClick(View v) {
       // Save the opt in preference
-      String fileName = getString(R.string.physical_web_preference_file_name);
-      SharedPreferences sharedPreferences = getSharedPreferences(fileName, Context.MODE_PRIVATE);
+      String preferencesKey = getString(R.string.main_prefs_key);
+      SharedPreferences sharedPreferences = getSharedPreferences(preferencesKey,
+                                                                 Context.MODE_PRIVATE);
       SharedPreferences.Editor editor = sharedPreferences.edit();
       editor.putBoolean(getString(R.string.user_opted_in_flag), true);
       editor.apply();

--- a/android/PhysicalWeb/app/src/main/res/values/strings.xml
+++ b/android/PhysicalWeb/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
     <string name="action_settings">Settings</string>
     <string name="oob_accept_and_continue">ACCEPT &amp; CONTINUE</string>
     <string name="user_opted_in_flag">userOptedIn</string>
-    <string name="physical_web_preference_file_name">physical_web_preferences</string>
+    <string name="main_prefs_key">org.physical_web.physicalweb.MAIN_PREFS</string>
     <string name="metadata_loading">loading&#8230;</string>
     <string name="proxy_go_link_base_url">https://url-caster.appspot.com/go?url=</string>
     <string name="ranging_debug_tx_power_prefix">tx: </string>


### PR DESCRIPTION
"""
When naming your shared preference files, you should use a name that's
uniquely identifiable to your app, such as
"com.example.myapp.PREFERENCE_FILE_KEY"
"""
http://developer.android.com/training/basics/data-storage/shared-preferences.html