### PR TITLE
match new API that supports extensions

### DIFF
--- a/ios/PhyWeb/Backend/PWBeaconManager.m
+++ b/ios/PhyWeb/Backend/PWBeaconManager.m
@@ -65,7 +65,6 @@
     return nil;
   }
   _beaconsDict = [NSMutableDictionary dictionary];
-  _scanner = [[UBUriBeaconScanner alloc] init];
   _changeBlocks = [NSMutableArray array];
   _configurationChangeBlocks = [NSMutableArray array];
   _requests = [NSMutableArray array];
@@ -119,7 +118,12 @@
   _startTime = [NSDate timeIntervalSinceReferenceDate];
   _started = YES;
   PWBeaconManager* __weak weakSelf = self;
-  _scanner = [[UBUriBeaconScanner alloc] init];
+#if TODAY_EXTENSION
+  _scanner = [[UBUriBeaconScanner alloc] initWithApplication:nil];
+#else
+  _scanner = [[UBUriBeaconScanner alloc]
+      initWithApplication:[UIApplication sharedApplication]];
+#endif
   [_scanner startScanningWithUpdateBlock:^{
     PWBeaconManager* strongSelf = weakSelf;
     [strongSelf _updateBeacons];


### PR DESCRIPTION
Since we can't refer to `[UIApplication sharedApplication]` in extensions, the API implementation of UriBeacon has been modified (https://github.com/google/uribeacon/pull/256) to match that and then, Physical Web needs the following changes.

@mmocny 