### PR TITLE
[android] Get rid of flashing scanning animation

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
@@ -159,13 +159,14 @@ public class PwoDiscoveryService extends Service
     String preferencesKey = getString(R.string.discovery_service_prefs_key);
     SharedPreferences prefs = getSharedPreferences(preferencesKey, Context.MODE_PRIVATE);
     int prefsVersion = prefs.getInt(PREFS_VERSION_KEY, 0);
+    long now = new Date().getTime();
     if (prefsVersion != PREFS_VERSION) {
+      mScanStartTime = now;
       return;
     }
 
     // Don't load the cache if it's stale
     mScanStartTime = prefs.getLong(SCAN_START_TIME_KEY, 0);
-    long now = new Date().getTime();
     if (now - mScanStartTime >= SCAN_STALE_TIME_MILLIS) {
       mScanStartTime = now;
       return;
@@ -509,5 +510,9 @@ public class PwoDiscoveryService extends Service
 
   public long getScanStartTime() {
     return mScanStartTime;
+  }
+
+  public boolean hasResults() {
+   return !mUrlToPwoMetadata.isEmpty();
   }
 }

--- a/android/PhysicalWeb/app/src/main/res/layout/fragment_nearby_beacons.xml
+++ b/android/PhysicalWeb/app/src/main/res/layout/fragment_nearby_beacons.xml
@@ -10,6 +10,7 @@
 
         <ListView
             android:id="@android:id/list"
+            android:alpha="0"
             android:layout_height="wrap_content"
             android:layout_width="wrap_content"
             android:divider="@null">
@@ -21,6 +22,7 @@
             android:text="@string/empty_nearby_beacons_list_text"
             android:textSize="16sp"
             android:textColor="#5A5A5A"
+            android:alpha="0"
             android:drawableTop="@drawable/scanning_animation"
             android:drawablePadding="16dp"
             android:layout_alignParentBottom="true"


### PR DESCRIPTION
If we load cached results, we don't need to show the scanning
animation.  This change makes sure that animation doesn't get
shown if it's not needed.