### PR TITLE
[android] Create a service to listen to the screen

### DIFF
--- a/android/PhysicalWeb/app/src/main/AndroidManifest.xml
+++ b/android/PhysicalWeb/app/src/main/AndroidManifest.xml
@@ -39,11 +39,16 @@
             android:exported="false">
         </service>
 
+        <service
+            android:name=".ScreenListenerService"
+            android:enabled="true"
+            android:exported="false">
+        </service>
+
         <receiver
             android:name=".AutostartPwoDiscoveryServiceReceiver">
             <intent-filter>
-                <action android:name="android.intent.action.SCREEN_ON" />
-                <action android:name="android.intent.action.SCREEN_OFF" />
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
 

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/AutostartPwoDiscoveryServiceReceiver.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/AutostartPwoDiscoveryServiceReceiver.java
@@ -34,12 +34,7 @@ public class AutostartPwoDiscoveryServiceReceiver extends BroadcastReceiver {
       return;
     }
 
-    // Handle the intent
-    Intent discoveryIntent = new Intent(context, PwoDiscoveryService.class);
-    if (intent.getAction().equals(Intent.ACTION_SCREEN_ON)) {
-      context.startService(discoveryIntent);
-    } else if (intent.getAction().equals(Intent.ACTION_SCREEN_OFF)) {
-      context.stopService(discoveryIntent);
-    }
+    Intent newIntent = new Intent(context, ScreenListenerService.class);
+    context.startService(newIntent);
   }
 }

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/MainActivity.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/MainActivity.java
@@ -90,6 +90,8 @@ public class MainActivity extends Activity {
     if (checkIfUserHasOptedIn()) {
       ensureBluetoothIsEnabled();
       showNearbyBeaconsFragment();
+      Intent intent = new Intent(this, ScreenListenerService.class);
+      startService(intent);
     } else {
       // Show the oob activity
       Intent intent = new Intent(this, OobActivity.class);

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/ScreenListenerService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/ScreenListenerService.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.physical_web.physicalweb;
+
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.IBinder;
+
+/**
+ * This is a service registers a broadcast receiver to listen for screen on/off events.
+ * It is a very unfortunate service that must exist because we can't register for screen on/off
+ * in the manifest.
+ */
+
+public class ScreenListenerService extends Service {
+  private BroadcastReceiver mScreenStateBroadcastReceiver = new BroadcastReceiver() {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+      Intent discoveryIntent = new Intent(context, PwoDiscoveryService.class);
+      if (intent.getAction().equals(Intent.ACTION_SCREEN_ON)) {
+        context.startService(discoveryIntent);
+      } else if (intent.getAction().equals(Intent.ACTION_SCREEN_OFF)) {
+        context.stopService(discoveryIntent);
+      }
+    }
+  };
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    IntentFilter intentFilter = new IntentFilter();
+    intentFilter.addAction(Intent.ACTION_SCREEN_ON);
+    intentFilter.addAction(Intent.ACTION_SCREEN_OFF);
+    registerReceiver(mScreenStateBroadcastReceiver, intentFilter);
+  }
+
+  @Override
+  public void onDestroy() {
+    unregisterReceiver(mScreenStateBroadcastReceiver);
+    super.onDestroy();
+  }
+
+  @Override
+  public IBinder onBind(Intent intent) {
+    // Nothing should bind to this service
+    return null;
+  }
+}


### PR DESCRIPTION
We have switched from having the PwoDiscoveryService be a long running
service, but SCREEN_ON and SCREEN_OFF don't actually trigger when set
in the manifest.  Therefore, let's create a second service that will
monitor these things.  Since the code is isolated, it will be easy to
remove if/when we come up with a better solution