### PR TITLE
[android] Restore old preference file name

### DIFF
--- a/android/PhysicalWeb/app/src/main/res/values/strings.xml
+++ b/android/PhysicalWeb/app/src/main/res/values/strings.xml
@@ -35,7 +35,9 @@
     <string name="action_settings">Settings</string>
     <string name="oob_accept_and_continue">ACCEPT &amp; CONTINUE</string>
     <string name="user_opted_in_flag">userOptedIn</string>
-    <string name="main_prefs_key">org.physical_web.physicalweb.MAIN_PREFS</string>
+    <string name="main_prefs_key">physical_web_preferences</string>
+    <!-- The following is a more appropriate name, but would require special code to migrate users -->
+    <!-- string name="main_prefs_key">org.physical_web.physicalweb.MAIN_PREFS</string -->
     <string name="discovery_service_prefs_key">org.physical_web.physicalweb.DISCOVERY_SERVICE_PREFS</string>
     <string name="metadata_loading">loading&#8230;</string>
     <string name="proxy_go_link_base_url">https://url-caster.appspot.com/go?url=</string>


### PR DESCRIPTION
This will prevent users from having to accept the terms in the Oob
activity twice.