### PR TITLE
[android] Cancel prev. notifications on new scan

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
@@ -196,6 +196,7 @@ public class PwoDiscoveryService extends Service
     initialize();
     restoreCache();
 
+    mNotificationManager.cancelAll();
     mHandler.postDelayed(mFirstScanTimeout, FIRST_SCAN_TIME_MILLIS);
     mHandler.postDelayed(mSecondScanTimeout, SECOND_SCAN_TIME_MILLIS);
     for (PwoDiscoverer pwoDiscoverer : mPwoDiscoverers) {


### PR DESCRIPTION
This restores previous behavior and fixes a bug.  Currently, if
a user encounters 2+ URLs and then later encounters exactly 1 URL,
two notifications are displayed.  If we kill all the notifications
at the beginning of a scan, we remove the risk of this happening.