### PR TITLE
[android] Restart scanners on refresh

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/MdnsPwoDiscoverer.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/MdnsPwoDiscoverer.java
@@ -53,6 +53,10 @@ class MdnsPwoDiscoverer extends PwoDiscoverer {
     public void onDiscoveryStopped(String serviceType) {
       Log.i(TAG, "Discovery stopped: " + serviceType);
       mState = State.STOPPED;
+      if (toRestart) {
+        toRestart = false;
+        startScan();
+      }
     }
 
     @Override
@@ -75,10 +79,12 @@ class MdnsPwoDiscoverer extends PwoDiscoverer {
     STARTED,
   }
   private State mState;
+  private boolean toRestart;
 
   public MdnsPwoDiscoverer(Context context) {
     mNsdManager = (NsdManager) context.getSystemService(Context.NSD_SERVICE);
     mState = State.STOPPED;
+    toRestart = false;
   }
 
   @Override
@@ -86,8 +92,8 @@ class MdnsPwoDiscoverer extends PwoDiscoverer {
     if (mState != State.STOPPED) {
       return;
     }
-    mNsdManager.discoverServices(MDNS_SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, mDiscoveryListener);
     mState = State.WAITING;
+    mNsdManager.discoverServices(MDNS_SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, mDiscoveryListener);
   }
 
   @Override
@@ -95,7 +101,13 @@ class MdnsPwoDiscoverer extends PwoDiscoverer {
     if (mState != State.STARTED) {
       return;
     }
-    mNsdManager.stopServiceDiscovery(mDiscoveryListener);
     mState = State.WAITING;
+    mNsdManager.stopServiceDiscovery(mDiscoveryListener);
+  }
+
+  @Override
+  public synchronized void restartScan() {
+    toRestart = true;
+    stopScan();
   }
 }

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoverer.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoverer.java
@@ -35,6 +35,11 @@ abstract class PwoDiscoverer {
     stopScanImpl();
   }
 
+  public void restartScan() {
+    stopScan();
+    startScan();
+  }
+
   public void setCallback(PwoDiscoveryCallback pwoDiscoveryCallback) {
     mPwoDiscoveryCallback = pwoDiscoveryCallback;
   }

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoDiscoveryService.java
@@ -497,12 +497,19 @@ public class PwoDiscoveryService extends Service
 
   public void requestPwoMetadata(PwoResponseCallback pwoResponseCallback,
                                  boolean requestCachedPwos) {
+    mPwoResponseCallbacks.add(pwoResponseCallback);
     if (requestCachedPwos) {
       for (PwoMetadata pwoMetadata : mUrlToPwoMetadata.values()) {
         pwoResponseCallback.onPwoDiscovered(pwoMetadata);
       }
+    } else {
+      // If the client isn't requesting cached PWOs, let's restart the scanners so that those
+      // scanners that only discover a PWO once (and not repeatedly) will have an opportunity
+      // to report all results.
+      for (PwoDiscoverer pwoDiscoverer : mPwoDiscoverers) {
+        pwoDiscoverer.restartScan();
+      }
     }
-    mPwoResponseCallbacks.add(pwoResponseCallback);
   }
 
   public void removeCallbacks(PwoResponseCallback pwoResponseCallback) {


### PR DESCRIPTION
This fixes a bug with refreshing mdns results, since mdns results
are typically only found once in a scan, and not frequently like ble
results.