### PR TITLE
[android] add group to UrlMetadata and debug view

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
@@ -504,6 +504,7 @@ public class NearbyBeaconsFragment extends ListFragment
 
       TextView rankView = (TextView) view.findViewById(R.id.metadata_debug_rank);
       TextView pwsTripTimeView = (TextView) view.findViewById(R.id.metadata_debug_pws_trip_time);
+      TextView groupView = (TextView) view.findViewById(R.id.metadata_debug_group);
       if (pwoMetadata.hasUrlMetadata()) {
         UrlMetadata urlMetadata = pwoMetadata.urlMetadata;
         double rank = urlMetadata.rank;
@@ -515,9 +516,13 @@ public class NearbyBeaconsFragment extends ListFragment
         String pwsTripTimeString = "" + getString(R.string.metadata_debug_pws_trip_time_prefix)
             + new DecimalFormat("##.##s").format(pwsTripTime);
         pwsTripTimeView.setText(pwsTripTimeString);
+
+        String groupString = getString(R.string.metadata_debug_group_prefix) + urlMetadata.group;
+        groupView.setText(groupString);
       } else {
         rankView.setText("");
         pwsTripTimeView.setText("");
+        groupView.setText("");
       }
     }
 

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoMetadata.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoMetadata.java
@@ -139,6 +139,7 @@ class PwoMetadata implements Comparable<PwoMetadata> {
     private static final String ICON_URL_KEY = "iconUrl";
     private static final String ICON_KEY = "icon";
     private static final String RANK_KEY = "rank";
+    private static final String GROUP_KEY = "group";
     public String id;
     public String siteUrl;
     public String displayUrl;
@@ -147,6 +148,7 @@ class PwoMetadata implements Comparable<PwoMetadata> {
     public String iconUrl;
     public Bitmap icon;
     public double rank;
+    public String group;
 
     public UrlMetadata() {
     }
@@ -176,6 +178,7 @@ class PwoMetadata implements Comparable<PwoMetadata> {
         jsonObj.put(ICON_KEY, Base64.encodeToString(bitmapData, Base64.DEFAULT));
       }
       jsonObj.put(RANK_KEY, rank);
+      jsonObj.put(GROUP_KEY, group);
       return jsonObj;
     }
 
@@ -196,6 +199,7 @@ class PwoMetadata implements Comparable<PwoMetadata> {
         urlMetadata.icon = BitmapFactory.decodeByteArray(bitmapData, 0, bitmapData.length);
       }
       urlMetadata.rank = jsonObj.getDouble(RANK_KEY);
+      urlMetadata.group = jsonObj.getString(GROUP_KEY);
       return urlMetadata;
     }
 

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwsClient.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwsClient.java
@@ -245,6 +245,7 @@ class PwsClient {
             urlMetadata.description = jsonUrlMetadata.optString("description");
             urlMetadata.iconUrl = jsonUrlMetadata.optString("icon");
             urlMetadata.rank = jsonUrlMetadata.getDouble("rank");
+            urlMetadata.group = jsonUrlMetadata.optString("group");
           } catch (JSONException e) {
             Log.i(TAG, "Pws gave bad JSON: " + e);
             continue;

--- a/android/PhysicalWeb/app/src/main/res/layout/list_item_nearby_beacon.xml
+++ b/android/PhysicalWeb/app/src/main/res/layout/list_item_nearby_beacon.xml
@@ -148,6 +148,13 @@
             android:textSize="16sp"
             android:textColor="#bbbbbb"
             android:id="@+id/metadata_debug_pws_trip_time"/>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:textSize="16sp"
+            android:textColor="#bbbbbb"
+            android:id="@+id/metadata_debug_group"/>
     </LinearLayout>
 
 </LinearLayout>

--- a/android/PhysicalWeb/app/src/main/res/values/strings.xml
+++ b/android/PhysicalWeb/app/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="metadata_debug_rank_prefix">rank: </string>
     <string name="metadata_debug_scan_time_prefix">scan: </string>
     <string name="metadata_debug_pws_trip_time_prefix">pws: </string>
+    <string name="metadata_debug_group_prefix">group: </string>
     <string name="summary_notification_pull_down">Pull down to see them.</string>
     <string name="url_shortening_error">URL is too long. Please use a shortener.</string>
     <string name="error_bluetooth_support">Device does not support Bluetooth</string>


### PR DESCRIPTION
This adds the "group" key to UrlMetadata and displays it in debug view.  Currently the PWS doesn't return any groups so it should be empty.