### PR TITLE
Expose groupid in Android client

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
@@ -504,7 +504,7 @@ public class NearbyBeaconsFragment extends ListFragment
 
       TextView rankView = (TextView) view.findViewById(R.id.metadata_debug_rank);
       TextView pwsTripTimeView = (TextView) view.findViewById(R.id.metadata_debug_pws_trip_time);
-      TextView groupView = (TextView) view.findViewById(R.id.metadata_debug_group);
+      TextView groupidView = (TextView) view.findViewById(R.id.metadata_debug_groupid);
       if (pwoMetadata.hasUrlMetadata()) {
         UrlMetadata urlMetadata = pwoMetadata.urlMetadata;
         double rank = urlMetadata.rank;
@@ -517,12 +517,13 @@ public class NearbyBeaconsFragment extends ListFragment
             + new DecimalFormat("##.##s").format(pwsTripTime);
         pwsTripTimeView.setText(pwsTripTimeString);
 
-        String groupString = getString(R.string.metadata_debug_group_prefix) + urlMetadata.group;
-        groupView.setText(groupString);
+        String groupidString = getString(R.string.metadata_debug_groupid_prefix)
+                + urlMetadata.groupid;
+        groupidView.setText(groupidString);
       } else {
         rankView.setText("");
         pwsTripTimeView.setText("");
-        groupView.setText("");
+        groupidView.setText("");
       }
     }
 

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoMetadata.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwoMetadata.java
@@ -139,7 +139,7 @@ class PwoMetadata implements Comparable<PwoMetadata> {
     private static final String ICON_URL_KEY = "iconUrl";
     private static final String ICON_KEY = "icon";
     private static final String RANK_KEY = "rank";
-    private static final String GROUP_KEY = "groupid";
+    private static final String GROUPID_KEY = "groupid";
     public String id;
     public String siteUrl;
     public String displayUrl;
@@ -148,7 +148,7 @@ class PwoMetadata implements Comparable<PwoMetadata> {
     public String iconUrl;
     public Bitmap icon;
     public double rank;
-    public String group;
+    public String groupid;
 
     public UrlMetadata() {
     }
@@ -178,7 +178,7 @@ class PwoMetadata implements Comparable<PwoMetadata> {
         jsonObj.put(ICON_KEY, Base64.encodeToString(bitmapData, Base64.DEFAULT));
       }
       jsonObj.put(RANK_KEY, rank);
-      jsonObj.put(GROUP_KEY, group);
+      jsonObj.put(GROUPID_KEY, groupid);
       return jsonObj;
     }
 
@@ -199,7 +199,7 @@ class PwoMetadata implements Comparable<PwoMetadata> {
         urlMetadata.icon = BitmapFactory.decodeByteArray(bitmapData, 0, bitmapData.length);
       }
       urlMetadata.rank = jsonObj.getDouble(RANK_KEY);
-      urlMetadata.group = jsonObj.getString(GROUP_KEY);
+      urlMetadata.groupid = jsonObj.getString(GROUPID_KEY);
       return urlMetadata;
     }
 

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwsClient.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PwsClient.java
@@ -245,7 +245,7 @@ class PwsClient {
             urlMetadata.description = jsonUrlMetadata.optString("description");
             urlMetadata.iconUrl = jsonUrlMetadata.optString("icon");
             urlMetadata.rank = jsonUrlMetadata.getDouble("rank");
-            urlMetadata.group = jsonUrlMetadata.optString("group");
+            urlMetadata.groupid = jsonUrlMetadata.optString("groupid");
           } catch (JSONException e) {
             Log.i(TAG, "Pws gave bad JSON: " + e);
             continue;

--- a/android/PhysicalWeb/app/src/main/res/layout/list_item_nearby_beacon.xml
+++ b/android/PhysicalWeb/app/src/main/res/layout/list_item_nearby_beacon.xml
@@ -149,12 +149,14 @@
             android:textColor="#bbbbbb"
             android:id="@+id/metadata_debug_pws_trip_time"/>
         <TextView
-            android:layout_width="wrap_content"
+            android:layout_width="100sp"
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:textSize="16sp"
             android:textColor="#bbbbbb"
-            android:id="@+id/metadata_debug_group"/>
+            android:id="@+id/metadata_debug_groupid"
+            android:ellipsize="end"
+            android:singleLine="true"/>
     </LinearLayout>
 
 </LinearLayout>

--- a/android/PhysicalWeb/app/src/main/res/values/strings.xml
+++ b/android/PhysicalWeb/app/src/main/res/values/strings.xml
@@ -47,7 +47,7 @@
     <string name="metadata_debug_rank_prefix">rank: </string>
     <string name="metadata_debug_scan_time_prefix">scan: </string>
     <string name="metadata_debug_pws_trip_time_prefix">pws: </string>
-    <string name="metadata_debug_group_prefix">group: </string>
+    <string name="metadata_debug_groupid_prefix">group: </string>
     <string name="summary_notification_pull_down">Pull down to see them.</string>
     <string name="url_shortening_error">URL is too long. Please use a shortener.</string>
     <string name="error_bluetooth_support">Device does not support Bluetooth</string>


### PR DESCRIPTION
* Fix the groupid key for incoming PWS messages ('group' -> 'groupid')
* Truncate the groupid to 4 characters for debug display

Note: groupid is currently only supported with the DEV endpoint url.
Caching behavior will cause the field to be blank in most cases as the
client defaults to PROD until debug mode is enabled.