### PR TITLE
Use the URL shortener for non-ASCII URLs

### DIFF
--- a/android/PhysicalWeb/app/src/main/res/values/strings.xml
+++ b/android/PhysicalWeb/app/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="metadata_debug_groupid_prefix">group: </string>
     <string name="summary_notification_pull_down">Pull down to see them.</string>
     <string name="url_shortening_error">URL is too long. Please use a shortener.</string>
+    <string name="url_charset_error">Non-ASCII characters unsupported in URL. Please use a shortener.</string>
     <string name="error_bluetooth_support">Device does not support Bluetooth</string>
 
 </resources>


### PR DESCRIPTION
Detect when a URL uses non-US-ASCII characters and automatically use the URL shortener.
If the shortener chokes on a URL, make sure we display an appropriate error message (ie, don't say the URL is too long if it isn't).