### PR TITLE
Add a UrlDeviceJsonSerializer to collection lib

### DIFF
--- a/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
@@ -15,6 +15,9 @@
  */
 package org.physical_web.collection;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,14 +25,20 @@ import java.util.Map;
  * Collection of Physical Web URL devices and related metadata.
  */
 public class PhysicalWebCollection {
-  private Map<String, UrlDevice> mDeviceIdToUrlDeviceMap;
+  private final int SCHEMA_VERSION = 1;
+  private final String SCHEMA_VERSION_KEY = "schema";
   private final String DEVICES_KEY = "devices";
+  private final String TYPE_KEY = "type";
+  private final String DATA_KEY = "data";
+  private Map<String, UrlDevice> mDeviceIdToUrlDeviceMap;
+  private Map<Class, UrlDeviceJsonSerializer> mUrlDeviceTypeToUrlDeviceJsonSerializer;
 
   /**
    * Construct a PhysicalWebCollection.
    */
   public PhysicalWebCollection() {
     mDeviceIdToUrlDeviceMap = new HashMap<>();
+    mUrlDeviceTypeToUrlDeviceJsonSerializer = new HashMap<>();
   }
 
   /**
@@ -47,5 +56,106 @@ public class PhysicalWebCollection {
    */
   public UrlDevice getUrlDeviceById(String id) {
     return mDeviceIdToUrlDeviceMap.get(id);
+  }
+
+  /**
+   * Add a UrlDeviceJsonSerializer to be associated with a particular class.
+   * @param urlDeviceType the class UrlDevices to serialize and deserialize with this
+   *        serializer.
+   * @param urlDeviceJsonSerializer the serializer to use in serializing UrlDevices.
+   */
+  public <T extends UrlDevice> void addUrlDeviceJsonSerializer(
+      Class<? extends T> urlDeviceType,
+      UrlDeviceJsonSerializer<T> urlDeviceJsonSerializer) {
+    mUrlDeviceTypeToUrlDeviceJsonSerializer.put(urlDeviceType, urlDeviceJsonSerializer);
+  }
+
+  @SuppressWarnings("unchecked")
+  private JSONObject jsonSerializeUrlDevice(UrlDevice urlDevice)
+      throws PhysicalWebCollectionException {
+    // Loop through the superclasses of urlDevice to see which serializer we should use.
+    for (Class urlDeviceType = urlDevice.getClass();
+         UrlDevice.class.isAssignableFrom(urlDeviceType);
+         urlDeviceType = urlDeviceType.getSuperclass()) {
+      UrlDeviceJsonSerializer urlDeviceJsonSerializer =
+          mUrlDeviceTypeToUrlDeviceJsonSerializer.get(urlDeviceType);
+      UrlDeviceJsonSerializer<UrlDevice> specificUrlDeviceJsonSerializer =
+          (UrlDeviceJsonSerializer<UrlDevice>) urlDeviceJsonSerializer;
+      if (urlDeviceJsonSerializer != null) {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put(TYPE_KEY, urlDevice.getClass().getName());
+        jsonObject.put(DATA_KEY, specificUrlDeviceJsonSerializer.serialize(urlDevice));
+        return jsonObject;
+      }
+    }
+    throw new PhysicalWebCollectionException(
+        "No suitable UrlDeviceJsonSerializer found for " + urlDevice.getClass().getName());
+  }
+
+  /**
+   * Create a JSON object that represents this data structure.
+   * @return a JSON serialization of this data structure.
+   */
+  public JSONObject jsonSerialize() throws PhysicalWebCollectionException {
+    JSONObject jsonObject = new JSONObject();
+    JSONArray urlDevices = new JSONArray();
+    for (UrlDevice urlDevice : mDeviceIdToUrlDeviceMap.values()) {
+      urlDevices.put(jsonSerializeUrlDevice(urlDevice));
+    }
+    jsonObject.put(DEVICES_KEY, urlDevices);
+    jsonObject.put(SCHEMA_VERSION_KEY, SCHEMA_VERSION);
+    return jsonObject;
+  }
+
+  @SuppressWarnings("unchecked")
+  private UrlDevice jsonDeserializeUrlDevice(JSONObject jsonObject)
+      throws PhysicalWebCollectionException {
+    // Get the type and raw data out of the json object.
+    JSONObject dataJson = jsonObject.getJSONObject(DATA_KEY);
+    String typeName = jsonObject.getString(TYPE_KEY);
+    Class urlDeviceType = null;
+    try {
+      urlDeviceType = Class.forName(typeName);
+    } catch (ClassNotFoundException e) {
+      throw new PhysicalWebCollectionException(
+          "No suitable UrlDeviceJsonSerializer found for " + typeName);
+    }
+
+    // Loop through the superclasses of urlDevice to see which serializer we should use.
+    for (;
+         UrlDevice.class.isAssignableFrom(urlDeviceType);
+         urlDeviceType = urlDeviceType.getSuperclass()) {
+      UrlDeviceJsonSerializer urlDeviceJsonSerializer =
+          mUrlDeviceTypeToUrlDeviceJsonSerializer.get(urlDeviceType);
+      UrlDeviceJsonSerializer<UrlDevice> specificUrlDeviceJsonSerializer =
+          (UrlDeviceJsonSerializer<UrlDevice>) urlDeviceJsonSerializer;
+      if (urlDeviceJsonSerializer != null) {
+        return specificUrlDeviceJsonSerializer.deserialize(dataJson);
+      }
+    }
+    throw new PhysicalWebCollectionException(
+        "No suitable UrlDeviceJsonSerializer found for " + typeName);
+  }
+
+  /**
+   * Populate this data structure with UrlDevices represented by a given JSON object.
+   * @param jsonObject a serialized PhysicalWebCollection.
+   */
+  public void jsonDeserialize(JSONObject jsonObject) throws PhysicalWebCollectionException {
+    // Check the schema version
+    int schemaVersion = jsonObject.getInt(SCHEMA_VERSION_KEY);
+    if (schemaVersion > SCHEMA_VERSION) {
+      throw new PhysicalWebCollectionException(
+          "Cannot handle schema version " + schemaVersion + ".  "
+          + "This library only knows of schema version " + SCHEMA_VERSION);
+    }
+
+    // Deserialize the UrlDevices
+    JSONArray urlDevices = jsonObject.getJSONArray(DEVICES_KEY);
+    for (int i = 0; i < urlDevices.length(); i++) {
+      JSONObject urlDeviceJson = urlDevices.getJSONObject(i);
+      UrlDevice urlDevice = jsonDeserializeUrlDevice(urlDeviceJson);
+      addUrlDevice(urlDevice);
+    }
   }
 }

--- a/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollectionException.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollectionException.java
@@ -15,24 +15,14 @@
  */
 package org.physical_web.collection;
 
-import org.json.JSONObject;
-
-import org.junit.Test;
-import static org.junit.Assert.*;
-
-import org.skyscreamer.jsonassert.JSONAssert;
-
 /**
- * SimpleUrlDevice unit test class.
+ * Exception class used when PhysicalWebCollection runs into problems.
  */
-public class SimpleUrlDeviceTest {
-  private final String ID1 = "id1";
-  private final String URL1 = "http://example.com";
-
-  @Test
-  public void constructorCreatesProperObject() {
-    UrlDevice urlDevice = new SimpleUrlDevice(ID1, URL1);
-    assertEquals(urlDevice.getId(), ID1);
-    assertEquals(urlDevice.getUrl(), URL1);
+public class PhysicalWebCollectionException extends Exception {
+  /**
+   * Construct a PhysicalWebCollectionException.
+   */
+  public PhysicalWebCollectionException(String message) {
+    super(message);
   }
 }

--- a/java/libs/src/main/java/org/physical_web/collection/SimpleUrlDevice.java
+++ b/java/libs/src/main/java/org/physical_web/collection/SimpleUrlDevice.java
@@ -21,9 +21,6 @@ import org.json.JSONObject;
  * A basic implementation of the UrlDevice interface.
  */
 public class SimpleUrlDevice implements UrlDevice {
-  private static final String DEVICE_TYPE = "simple";
-  private static final String ID_KEY = "id";
-  private static final String URL_KEY = "url";
   private String mId;
   private String mUrl;
 
@@ -53,16 +50,5 @@ public class SimpleUrlDevice implements UrlDevice {
    */
   public String getUrl() {
     return mUrl;
-  }
-
-  /**
-   * Creates a JSON object that represents the UrlDevice.
-   * @return The JSON object representing the UrlDevice.
-   */
-  public JSONObject toJsonObject() {
-    JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ID_KEY, mId);
-    jsonObject.put(URL_KEY, mUrl);
-    return jsonObject;
   }
 }

--- a/java/libs/src/main/java/org/physical_web/collection/SimpleUrlDeviceJsonSerializer.java
+++ b/java/libs/src/main/java/org/physical_web/collection/SimpleUrlDeviceJsonSerializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.physical_web.collection;
+
+import org.json.JSONObject;
+
+/**
+ * A simple UrlDevice serializer that only worries about core properties.
+ */
+public class SimpleUrlDeviceJsonSerializer implements UrlDeviceJsonSerializer<UrlDevice> {
+  private static final String ID_KEY = "id";
+  private static final String URL_KEY = "url";
+
+  /**
+   * Creates a JSON object that represents the UrlDevice.
+   * @param urlDevice The UrlDevice to serialize.
+   * @return The JSON object representing the UrlDevice.
+   */
+  public JSONObject serialize(UrlDevice urlDevice) {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put(ID_KEY, urlDevice.getId());
+    jsonObject.put(URL_KEY, urlDevice.getUrl());
+    return jsonObject;
+  }
+
+  /**
+   * Creates a UrlDevice represented by the supplied JSON object.
+   * @param jsonObject The serialized UrlDevice.
+   * @return The deserialized UrlDevice.
+   */
+  public SimpleUrlDevice deserialize(JSONObject jsonObject) {
+    String id = jsonObject.getString("id");
+    String url = jsonObject.getString("url");
+    return new SimpleUrlDevice(id, url);
+  }
+}

--- a/java/libs/src/main/java/org/physical_web/collection/UrlDevice.java
+++ b/java/libs/src/main/java/org/physical_web/collection/UrlDevice.java
@@ -15,8 +15,6 @@
  */
 package org.physical_web.collection;
 
-import org.json.JSONObject;
-
 /**
  * The interface defining a Physical Web URL device.
  */
@@ -34,13 +32,4 @@ public interface UrlDevice {
    * @return The broadcasted URL.
    */
   String getUrl();
-
-  /**
-   * Creates a JSON object that represents the UrlDevice.
-   * This will only be used in serialization and deserialization.
-   * UrlDevices that are not anticipated to be serialized or deserialized may just
-   * return null.
-   * @return The JSON object representing the UrlDevice.
-   */
-  JSONObject toJsonObject();
 }

--- a/java/libs/src/main/java/org/physical_web/collection/UrlDeviceJsonSerializer.java
+++ b/java/libs/src/main/java/org/physical_web/collection/UrlDeviceJsonSerializer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.physical_web.collection;
+
+import org.json.JSONObject;
+
+/**
+ * An interface that defines objects that can serialize and deserialize
+ * UrlDevices to and from JSON.
+ * @param <T extends UrlDevice> The implementation of UrlDevice that this
+ *        serializer is designed to serialize and deserialize.
+ */
+public interface UrlDeviceJsonSerializer<T extends UrlDevice> {
+  /**
+   * Creates a JSON object that represents the UrlDevice.
+   * @param urlDevice The UrlDevice to serialize.
+   * @return The JSON object representing the UrlDevice.
+   */
+  JSONObject serialize(T urlDevice);
+
+  /**
+   * Creates a UrlDevice represented by the supplied JSON object.
+   * @param jsonObject The serialized UrlDevice.
+   * @return The deserialized UrlDevice.
+   */
+  T deserialize(JSONObject jsonObject);
+}

--- a/java/libs/src/test/java/org/physical_web/collection/SimpleUrlDeviceJsonSerializerTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/SimpleUrlDeviceJsonSerializerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.physical_web.collection;
+
+import org.json.JSONObject;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import org.skyscreamer.jsonassert.JSONAssert;
+
+/**
+ * SimpleUrlDeviceJsonSerializer unit test class.
+ */
+public class SimpleUrlDeviceJsonSerializerTest {
+  private final String ID1 = "id1";
+  private final String URL1 = "http://example.com";
+
+  @Test
+  public void serializeWorks() {
+    SimpleUrlDevice simpleUrlDevice = new SimpleUrlDevice(ID1, URL1);
+    SimpleUrlDeviceJsonSerializer simpleUrlDeviceJsonSerializer =
+        new SimpleUrlDeviceJsonSerializer();
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("id", ID1);
+    jsonObject.put("url", URL1);
+    JSONAssert.assertEquals(simpleUrlDeviceJsonSerializer.serialize(simpleUrlDevice), jsonObject,
+                            true);
+  }
+
+  @Test
+  public void deserializeWorks() {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("id", ID1);
+    jsonObject.put("url", URL1);
+    SimpleUrlDeviceJsonSerializer simpleUrlDeviceJsonSerializer =
+        new SimpleUrlDeviceJsonSerializer();
+    SimpleUrlDevice simpleUrlDevice = simpleUrlDeviceJsonSerializer.deserialize(jsonObject);
+    assertEquals(simpleUrlDevice.getId(), ID1);
+    assertEquals(simpleUrlDevice.getUrl(), URL1);
+  }
+}


### PR DESCRIPTION
This class simplifies serialization a bit since it permits the
PhysicalWebCollection class to decide which serializer is associated
with which Pwo.