### PR TITLE
Add PwsMetadata to collection lib for storing URL metadata.

### DIFF
--- a/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
@@ -30,8 +30,12 @@ public class PhysicalWebCollection {
   private final String DEVICES_KEY = "devices";
   private final String TYPE_KEY = "type";
   private final String DATA_KEY = "data";
+  private final String METADATA_KEY = "metadata";
+  private final String REQUESTURL_KEY = "requesturl";
+  private final String SITEURL_KEY = "siteurl";
   private Map<String, UrlDevice> mDeviceIdToUrlDeviceMap;
   private Map<Class, UrlDeviceJsonSerializer> mUrlDeviceTypeToUrlDeviceJsonSerializer;
+  private Map<String, PwsResult> mRequestUrlToPwsResultMap;
 
   /**
    * Construct a PhysicalWebCollection.
@@ -39,6 +43,7 @@ public class PhysicalWebCollection {
   public PhysicalWebCollection() {
     mDeviceIdToUrlDeviceMap = new HashMap<>();
     mUrlDeviceTypeToUrlDeviceJsonSerializer = new HashMap<>();
+    mRequestUrlToPwsResultMap = new HashMap<>();
   }
 
   /**
@@ -47,6 +52,14 @@ public class PhysicalWebCollection {
    */
   public void addUrlDevice(UrlDevice urlDevice) {
     mDeviceIdToUrlDeviceMap.put(urlDevice.getId(), urlDevice);
+  }
+
+  /**
+   * Add URL metadata to the collection.
+   * @param pwsResult The PwsResult to add.
+   */
+  public void addMetadata(PwsResult pwsResult) {
+    mRequestUrlToPwsResultMap.put(pwsResult.getRequestUrl(), pwsResult);
   }
 
   /**
@@ -103,6 +116,9 @@ public class PhysicalWebCollection {
       urlDevices.put(jsonSerializeUrlDevice(urlDevice));
     }
     jsonObject.put(DEVICES_KEY, urlDevices);
+
+    // TODO(mattreynolds): URL metadata serialization
+
     jsonObject.put(SCHEMA_VERSION_KEY, SCHEMA_VERSION);
     return jsonObject;
   }
@@ -157,5 +173,7 @@ public class PhysicalWebCollection {
       UrlDevice urlDevice = jsonDeserializeUrlDevice(urlDeviceJson);
       addUrlDevice(urlDevice);
     }
+
+    // TODO(mattreynolds): URL metadata deserialization
   }
 }

--- a/java/libs/src/main/java/org/physical_web/collection/PwsResult.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PwsResult.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.physical_web.collection;
+
+/**
+ * Metadata returned from the Physical Web Service for a single URL.
+ */
+public class PwsResult {
+  private String mRequestUrl;
+  private String mSiteUrl;
+
+  /**
+   * Construct a PwsResult.
+   * @param requestUrl The request URL, as broadcasted by the device
+   * @param siteUrl The site URL, as reported by PWS
+   */
+  PwsResult(String requestUrl, String siteUrl) {
+    mRequestUrl = requestUrl;
+    mSiteUrl = siteUrl;
+  }
+
+  /**
+   * Fetches the request URL.
+   * The request URL is the query sent to the Physical Web Service and should be identical to the
+   * URL broadcasted by the device.
+   * @return The request URL
+   */
+  public String getRequestUrl() {
+    return mRequestUrl;
+  }
+
+  /**
+   * Fetches the site URL.
+   * The site URL is returned by the Physical Web Service. It may differ from the request URL if
+   * a redirector or URL shortener was used.
+   * @return The site URL
+   */
+  public String getSiteUrl() {
+    return mSiteUrl;
+  }
+}


### PR DESCRIPTION
I'm using "requestUrl" to mean the URL broadcast by the beacon that is sent as a query to PWS, and "siteUrl" to mean the URL returned by PWS that we'll navigate to when the user selects the item.