### PR TITLE
Deserialize to UrlDevice, not to specific subclass

### DIFF
--- a/java/libs/src/main/java/org/physical_web/collection/UrlDeviceJsonSerializer.java
+++ b/java/libs/src/main/java/org/physical_web/collection/UrlDeviceJsonSerializer.java
@@ -36,5 +36,5 @@ public interface UrlDeviceJsonSerializer<T extends UrlDevice> {
    * @param jsonObject The serialized UrlDevice.
    * @return The deserialized UrlDevice.
    */
-  T deserialize(JSONObject jsonObject);
+  UrlDevice deserialize(JSONObject jsonObject);
 }


### PR DESCRIPTION
The UrlDeviceJsonSerializer is designed to serialize a specific
subclass of UrlDevice and de serialize a specific subclass of
UrlDevice.  We should not dictate what it deserializes to, only what
it deserializes from.  This will allow updated versions of clients to
transition between subclasses of UrlDevice.