### PR TITLE
Add metadata serialization and unit tests

### DIFF
--- a/java/libs/src/test/java/org/physical_web/collection/PhysicalWebCollectionTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/PhysicalWebCollectionTest.java
@@ -31,13 +31,16 @@ public class PhysicalWebCollectionTest {
   private static final String ID1 = "id1";
   private static final String ID2 = "id2";
   private static final String URL1 = "http://example.com";
+  private static final String URL2 = "http://physical-web.org";
   private PhysicalWebCollection physicalWebCollection1;
 
   @Before
   public void setUp() {
     physicalWebCollection1 = new PhysicalWebCollection();
     UrlDevice urlDevice = new SimpleUrlDevice(ID1, URL1);
+    PwsResult pwsResult = new PwsResult(URL1, URL1);
     physicalWebCollection1.addUrlDevice(urlDevice);
+    physicalWebCollection1.addMetadata(pwsResult);
   }
 
   @Test
@@ -48,9 +51,22 @@ public class PhysicalWebCollectionTest {
   }
 
   @Test
-  public void getUrlDeviceByReturnsNullForMissingUrlDevice() {
+  public void getUrlDeviceByIdReturnsNullForMissingUrlDevice() {
     UrlDevice fetchedUrlDevice = physicalWebCollection1.getUrlDeviceById(ID2);
     assertNull(fetchedUrlDevice);
+  }
+
+  @Test
+  public void getMetadataByRequestUrlReturnsFoundMetadata() {
+    PwsResult pwsResult = physicalWebCollection1.getMetadataByBroadcastUrl(URL1);
+    assertEquals(pwsResult.getRequestUrl(), URL1);
+    assertEquals(pwsResult.getSiteUrl(), URL1);
+  }
+
+  @Test
+  public void getMetadataByRequestUrlReturnsNullForMissingMetadata() {
+    PwsResult pwsResult = physicalWebCollection1.getMetadataByBroadcastUrl(URL2);
+    assertNull(pwsResult);
   }
 
   @Test
@@ -65,6 +81,10 @@ public class PhysicalWebCollectionTest {
         + "            \"id\": \"" + ID1 + "\","
         + "            \"url\": \"" + URL1 + "\""
         + "        }"
+        + "    }],"
+        + "    \"metadata\": [{"
+        + "        \"requesturl\": \"" + URL1 + "\","
+        + "        \"siteurl\": \"" + URL1 + "\""
         + "    }]"
         + "}");
     JSONAssert.assertEquals(physicalWebCollection1.jsonSerialize(), jsonObject, true);
@@ -89,13 +109,20 @@ public class PhysicalWebCollectionTest {
         + "            \"id\": \"" + ID1 + "\","
         + "            \"url\": \"" + URL1 + "\""
         + "        }"
+        + "    }],"
+        + "    \"metadata\": [{"
+        + "        \"requesturl\": \"" + URL1 + "\","
+        + "        \"siteurl\": \"" + URL1 + "\""
         + "    }]"
         + "}");
     physicalWebCollection.jsonDeserialize(jsonObject);
     UrlDevice urlDevice = physicalWebCollection.getUrlDeviceById(ID1);
+    PwsResult pwsResult = physicalWebCollection.getMetadataByBroadcastUrl(URL1);
     assertNotNull(urlDevice);
     assertEquals(urlDevice.getId(), ID1);
     assertEquals(urlDevice.getUrl(), URL1);
+    assertEquals(pwsResult.getRequestUrl(), URL1);
+    assertEquals(pwsResult.getSiteUrl(), URL1);
   }
 
   @Test(expected = PhysicalWebCollectionException.class)

--- a/java/libs/src/test/java/org/physical_web/collection/PwsResultTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/PwsResultTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.physical_web.collection;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * PwsResult unit test class.
+ */
+public class PwsResultTest {
+  private static final String URL1 = "http://example.com";
+
+  @Test
+  public void constructorCreatesProperObject() {
+    PwsResult pwsResult = new PwsResult(URL1, URL1);
+    assertEquals(pwsResult.getRequestUrl(), URL1);
+    assertEquals(pwsResult.getSiteUrl(), URL1);
+  }
+}


### PR DESCRIPTION
This exposes "requestUrl" in a public method, any suggestions on a better name for this?  broadcastUrl maybe?