### PR TITLE
Add a PwPair class to the collection library

### DIFF
--- a/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
@@ -18,8 +18,13 @@ package org.physical_web.collection;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Collection of Physical Web URL devices and related metadata.
@@ -210,5 +215,66 @@ public class PhysicalWebCollection {
       PwsResult pwsResult = jsonDeserializePwsResult(metadataPair);
       addMetadata(pwsResult);
     }
+  }
+
+  /**
+   * Return a list of PwPairs sorted by rank in descending order.
+   * @param dedupSiteUrls whether or not to dedup PwPairs by result urls.
+   * @param minRank the minimum rank to keep in the list.
+   * @return a sorted list of PwPairs.
+   */
+  public List<PwPair> getPwPairsSortedByRank(boolean dedupSiteUrls, double minRank) {
+    // Get all valid PwPairs.
+    List<PwPair> allPwPairs = new ArrayList<>();
+    for (UrlDevice urlDevice : mDeviceIdToUrlDeviceMap.values()) {
+      PwsResult pwsResult = mBroadcastUrlToPwsResultMap.get(urlDevice.getUrl());
+      if (pwsResult != null) {
+        allPwPairs.add(new PwPair(urlDevice, pwsResult));
+      }
+    }
+
+    // Sort the list in descending order.
+    Collections.sort(allPwPairs);
+    Collections.reverse(allPwPairs);
+
+    // Filter the list.
+    List<PwPair> ret = new ArrayList<>();
+    Set<String> siteUrls = new HashSet<>();
+    for (PwPair pwPair : allPwPairs) {
+      String siteUrl = pwPair.getPwsResult().getSiteUrl();
+      if (pwPair.getRank() >= minRank
+          && !dedupSiteUrls && !siteUrls.contains(siteUrl)) {
+        siteUrls.add(siteUrl);
+        ret.add(pwPair);
+      }
+    }
+
+    return ret;
+  }
+
+  /**
+   * Return a list of PwPairs sorted by rank in descending order.
+   * @param dedupSiteUrls whether or not to dedup PwPairs by result urls.
+   * @return a sorted list of PwPairs.
+   */
+  public List<PwPair> getPwPairsSortedByRank(boolean dedupSiteUrls) {
+    return getPwPairsSortedByRank(dedupSiteUrls, Double.NEGATIVE_INFINITY);
+  }
+
+  /**
+   * Return a list of PwPairs sorted by rank in descending order.
+   * @param minRank the minimum rank to keep in the list.
+   * @return a sorted list of PwPairs.
+   */
+  public List<PwPair> getPwPairsSortedByRank(double minRank) {
+    return getPwPairsSortedByRank(false, minRank);
+  }
+
+  /**
+   * Return a list of PwPairs sorted by rank in descending order.
+   * @return a sorted list of PwPairs.
+   */
+  public List<PwPair> getPwPairsSortedByRank() {
+    return getPwPairsSortedByRank(false, Double.NEGATIVE_INFINITY);
   }
 }

--- a/java/libs/src/main/java/org/physical_web/collection/PwPair.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PwPair.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.physical_web.collection;
+
+/**
+ * A physical web pair represents a UrlDevice and its corresponding PwsResult.
+ */
+public class PwPair implements Comparable<PwPair> {
+  private final UrlDevice mUrlDevice;
+  private final PwsResult mPwsResult;
+
+  /**
+   * Construct a PwPair.
+   */
+  public PwPair(UrlDevice urlDevice, PwsResult pwsResult) {
+    mUrlDevice = urlDevice;
+    mPwsResult = pwsResult;
+  }
+
+  /**
+   * Get the rank for the UrlDevice/PwsResult pair.
+   * @return the rank.
+   */
+  public double getRank() {
+    return mUrlDevice.getRank(mPwsResult);
+  }
+
+  /**
+   * Get the UrlDevice represented in the pair.
+   * @return the UrlDevice.
+   */
+  public UrlDevice getUrlDevice() {
+    return mUrlDevice;
+  }
+
+  /**
+   * Get the PwsResult represented in the pair.
+   * @return the PwsResult.
+   */
+  public PwsResult getPwsResult() {
+    return mPwsResult;
+  }
+
+  /**
+   * Unimplemented hash code method.
+   * @return 42.
+   */
+  public int hashCode() {
+    assert false : "hashCode not designed";
+    return 42;
+  }
+
+  /**
+   * Check if two PwPairs are equal based on rank.
+   * @param other the PwPair to compare to.
+   * @return true if the ranks are equal.
+   */
+  public boolean equals(Object other) {
+    if (other instanceof PwPair) {
+      PwPair otherPwPair = (PwPair) other;
+      return getRank() == otherPwPair.getRank();
+    }
+    return false;
+  }
+
+  /**
+   * Compare two PwPairs based on rank.
+   * @param other the PwPair to compare to.
+   * @return the comparison value.
+   */
+  public int compareTo(PwPair other) {
+    return new Double(getRank()).compareTo(other.getRank());
+  }
+}

--- a/java/libs/src/main/java/org/physical_web/collection/SimpleUrlDevice.java
+++ b/java/libs/src/main/java/org/physical_web/collection/SimpleUrlDevice.java
@@ -49,4 +49,14 @@ public class SimpleUrlDevice implements UrlDevice {
   public String getUrl() {
     return mUrl;
   }
+
+  /**
+   * Returns the rank of this device given its associated PwsResult.
+   * @param pwsResult is the response received from the Physical Web Service
+   *        for the url broadcasted by this UrlDevice.
+   * @return .5 (at the moment we don't have anything by which to judge rank)
+   */
+  public double getRank(PwsResult pwsResult) {
+    return .5;
+  }
 }

--- a/java/libs/src/main/java/org/physical_web/collection/UrlDevice.java
+++ b/java/libs/src/main/java/org/physical_web/collection/UrlDevice.java
@@ -32,4 +32,22 @@ public interface UrlDevice {
    * @return The broadcasted URL.
    */
   String getUrl();
+
+  /**
+   * Returns the rank for a given UrlDevice and its associated PwsResult.
+   * Guidelines for values:
+   * - Rank should typically be based on quality signals from the UrlDevice
+   *   and pwsResult.  E.g. if we know the UrlDevice knows its distance from
+   *   the user, we could combine this information with the quality signal from
+   *   pwsResult.
+   * - Rank should typically be between 0 and 1, but out of bounds values will
+   *   not be rounded into range.
+   * - 0 should represent extremely low quality
+   * - .5 should represent median quality
+   * - 1 should represent extremely high quality
+   * @param pwsResult is the response received from the Physical Web Service
+   *        for the url broadcasted by this UrlDevice.
+   * @return The rank of the UrlDevice, given its associated PwsResult.
+   */
+  double getRank(PwsResult pwsResult);
 }

--- a/java/libs/src/test/java/org/physical_web/collection/PhysicalWebCollectionTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/PhysicalWebCollectionTest.java
@@ -24,15 +24,51 @@ import org.junit.Test;
 
 import org.skyscreamer.jsonassert.JSONAssert;
 
+import java.util.List;
+
 /**
  * PhysicalWebCollection unit test class.
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public class PhysicalWebCollectionTest {
   private static final String ID1 = "id1";
   private static final String ID2 = "id2";
+  private static final String ID3 = "id3";
   private static final String URL1 = "http://example.com";
   private static final String URL2 = "http://physical-web.org";
   private PhysicalWebCollection physicalWebCollection1;
+  private PhysicalWebCollection physicalWebCollection2;
+
+  private static class RankedDevice implements UrlDevice {
+    private String mId;
+    private String mUrl;
+    private double mRank;
+
+    RankedDevice(String id, String url, double rank) {
+      mId = id;
+      mUrl = url;
+      mRank = rank;
+    }
+
+    public String getId() {
+      return mId;
+    }
+
+    public String getUrl() {
+      return mUrl;
+    }
+
+    public double getRank(PwsResult pwsResult) {
+      return mRank;
+    }
+  }
+
+  private void addRankedDevice(String id, String url, double rank) {
+    UrlDevice urlDevice = new RankedDevice(id, url, rank);
+    PwsResult pwsResult = new PwsResult(url, url);
+    physicalWebCollection2.addUrlDevice(urlDevice);
+    physicalWebCollection2.addMetadata(pwsResult);
+  }
 
   @Before
   public void setUp() {
@@ -41,6 +77,7 @@ public class PhysicalWebCollectionTest {
     PwsResult pwsResult = new PwsResult(URL1, URL1);
     physicalWebCollection1.addUrlDevice(urlDevice);
     physicalWebCollection1.addMetadata(pwsResult);
+    physicalWebCollection2 = new PhysicalWebCollection();
   }
 
   @Test
@@ -140,5 +177,45 @@ public class PhysicalWebCollectionTest {
         + "    }]"
         + "}");
     physicalWebCollection.jsonDeserialize(jsonObject);
+  }
+
+  public void getPwPairsSortedByRankNoFilters() {
+    addRankedDevice(ID1, URL1, .1);
+    addRankedDevice(ID2, URL2, .5);
+    addRankedDevice(ID3, URL2, .9);  // Duplicate URL
+    List<PwPair> pwPairs = physicalWebCollection2.getPwPairsSortedByRank();
+    assertEquals(pwPairs.size(), 3);
+    assertEquals(pwPairs.get(0).getUrlDevice().getId(), ID3);
+    assertEquals(pwPairs.get(1).getUrlDevice().getId(), ID2);
+    assertEquals(pwPairs.get(2).getUrlDevice().getId(), ID1);
+  }
+
+  public void getPwPairsSortedByRankFilterOnRank() {
+    addRankedDevice(ID1, URL1, .1);
+    addRankedDevice(ID2, URL2, .5);
+    addRankedDevice(ID3, URL2, .9);  // Duplicate URL
+    List<PwPair> pwPairs = physicalWebCollection2.getPwPairsSortedByRank(.2);
+    assertEquals(pwPairs.size(), 2);
+    assertEquals(pwPairs.get(0).getUrlDevice().getId(), ID3);
+    assertEquals(pwPairs.get(1).getUrlDevice().getId(), ID2);
+  }
+
+  public void getPwPairsSortedByRankFilterOnDuplicates() {
+    addRankedDevice(ID1, URL1, .1);
+    addRankedDevice(ID2, URL2, .5);
+    addRankedDevice(ID3, URL2, .9);  // Duplicate URL
+    List<PwPair> pwPairs = physicalWebCollection2.getPwPairsSortedByRank(true);
+    assertEquals(pwPairs.size(), 2);
+    assertEquals(pwPairs.get(0).getUrlDevice().getId(), ID3);
+    assertEquals(pwPairs.get(1).getUrlDevice().getId(), ID1);
+  }
+
+  public void getPwPairsSortedByRankFilterOnRankAndDuplicates() {
+    addRankedDevice(ID1, URL1, .1);
+    addRankedDevice(ID2, URL2, .5);
+    addRankedDevice(ID3, URL2, .9);  // Duplicate URL
+    List<PwPair> pwPairs = physicalWebCollection2.getPwPairsSortedByRank(true, .2);
+    assertEquals(pwPairs.size(), 1);
+    assertEquals(pwPairs.get(0).getUrlDevice().getId(), ID3);
   }
 }

--- a/java/libs/src/test/java/org/physical_web/collection/PwPairTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/PwPairTest.java
@@ -21,31 +21,25 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * SimpleUrlDevice unit test class.
+ * PwPair unit test class.
  */
-public class SimpleUrlDeviceTest {
+public class PwPairTest {
   private static final String ID1 = "id1";
   private static final String URL1 = "http://example.com";
   private SimpleUrlDevice urlDevice1;
+  private PwsResult pwsResult1;
+  private PwPair pwPair1;
 
   @Before
   public void setUp() {
     urlDevice1 = new SimpleUrlDevice(ID1, URL1);
+    pwsResult1 = new PwsResult(URL1, URL1);
+    pwPair1 = new PwPair(urlDevice1, pwsResult1);
   }
 
   @Test
-  public void getIdReturnsId() {
-    assertEquals(urlDevice1.getId(), ID1);
-  }
-
-  @Test
-  public void getUrlReturnsUrl() {
-    assertEquals(urlDevice1.getUrl(), URL1);
-  }
-
-  @Test
-  public void getRankReturnsPointFive() {
-    PwsResult pwsResult = new PwsResult(URL1, URL1);
-    assertEquals(.5, urlDevice1.getRank(pwsResult), .0001);
+  public void constructorCreatesProperObject() {
+    assertEquals(urlDevice1, pwPair1.getUrlDevice());
+    assertEquals(pwsResult1, pwPair1.getPwsResult());
   }
 }

--- a/java/libs/src/test/java/org/physical_web/collection/PwsResultTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/PwsResultTest.java
@@ -17,6 +17,7 @@ package org.physical_web.collection;
 
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -24,11 +25,16 @@ import org.junit.Test;
  */
 public class PwsResultTest {
   private static final String URL1 = "http://example.com";
+  private PwsResult pwsResult1;
+
+  @Before
+  public void setUp() {
+    pwsResult1 = new PwsResult(URL1, URL1);
+  }
 
   @Test
   public void constructorCreatesProperObject() {
-    PwsResult pwsResult = new PwsResult(URL1, URL1);
-    assertEquals(pwsResult.getRequestUrl(), URL1);
-    assertEquals(pwsResult.getSiteUrl(), URL1);
+    assertEquals(pwsResult1.getRequestUrl(), URL1);
+    assertEquals(pwsResult1.getSiteUrl(), URL1);
   }
 }


### PR DESCRIPTION
A Physical Web pair is a UrlDevice and its corresponding UrlResult.
This change also provides an api for gathering these pairs from the
PhysicalWebCollection.