### PR TITLE
Suppress findbugs warnings for DM_STRING_CTOR

### DIFF
--- a/java/libs/build.gradle
+++ b/java/libs/build.gradle
@@ -19,36 +19,23 @@ dependencies {
     testCompile 'org.skyscreamer:jsonassert:1.2.3'
 }
 
+findbugsMain {
+    reports {
+        xml.enabled = false
+        html.enabled = true
+    }
+}
+
+findbugs {
+    reportsDir = file("$project.buildDir/reports/findbugs")
+    excludeFilter = file("$project.rootDir/config/findbugs/exclude-filter.xml")
+}
+
 task checkstyle(type: Checkstyle) {
     configProperties.checkstyleSuppressionsPath = new File(rootDir, "config/checkstyle/suppressions.xml").absolutePath
     source 'src'
     include '**/*.java'
     exclude '**/gen/**'
-    classpath = files()
-}
-
-task findbugs(type: FindBugs, dependsOn: assemble) {
-    ignoreFailures = false
-    effort = "max"
-    reportLevel = "high"
-    classes = files("${project.rootDir}/build/classes")
-    excludeFilter = file("${project.rootDir}/config/findbugs/exclude-filter.xml")
-
-    source 'src'
-    include '**/*.java'
-    exclude '**/gen/**'
-
-    reports {
-        xml.enabled = false
-        html.enabled = true
-        xml {
-            destination "$project.buildDir/reports/findbugs/findbugs.xml"
-        }
-        html {
-            destination "$project.buildDir/reports/findbugs/findbugs.html"
-        }
-    }
-
     classpath = files()
 }
 
@@ -73,4 +60,4 @@ task pmd(type: Pmd) {
     }
 }
 
-check.dependsOn 'checkstyle', 'findbugs', 'pmd'
+check.dependsOn 'checkstyle', 'pmd'

--- a/java/libs/config/findbugs/exclude-filter.xml
+++ b/java/libs/config/findbugs/exclude-filter.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
   <Match>
-    <Class name="org.physical_web.physicalweb.ble.ScanRecord"/>
+    <Class name="org.physical_web.collection.PhysicalWebCollection"/>
+    <Method name="~json(Des|S)erializeUrlDevice"/>
+    <Bug pattern="DM_STRING_CTOR"/>
   </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Findbugs was warning us that passing a string argument to the exception constructor caused an inefficient extra call to new String().

This change suppresses that warning, along with some fixes to get gradle to respect the configured excludeFilter.  HTML report generation was also misconfigured and should now be enabled.