### PR TITLE
Clean up gradle build configuration for findbugs, checkstyle, pmd

### DIFF
--- a/java/libs/build.gradle
+++ b/java/libs/build.gradle
@@ -20,6 +20,9 @@ dependencies {
 }
 
 findbugsMain {
+    ignoreFailures = false
+    effort = "max"
+    reportLevel = "low"
     reports {
         xml.enabled = false
         html.enabled = true
@@ -31,33 +34,20 @@ findbugs {
     excludeFilter = file("$project.rootDir/config/findbugs/exclude-filter.xml")
 }
 
-task checkstyle(type: Checkstyle) {
-    configProperties.checkstyleSuppressionsPath = new File(rootDir, "config/checkstyle/suppressions.xml").absolutePath
-    source 'src'
-    include '**/*.java'
-    exclude '**/gen/**'
-    classpath = files()
+checkstyle {
+    configProperties.checkstyleSuppressionsPath = file("$project.rootDir/config/checkstyle/suppressions.xml")
 }
 
-task pmd(type: Pmd) {
-    ignoreFailures = false
-    ruleSetFiles = files("${project.rootDir}/config/pmd/pmd-ruleset.xml")
-    ruleSets = []
-
-    source 'src'
-    include '**/*.java'
-    exclude '**/gen/**'
-
+pmdMain {
     reports {
         xml.enabled = false
         html.enabled = true
-        xml {
-            destination "$project.buildDir/reports/pmd/pmd.xml"
-        }
-        html {
-            destination "$project.buildDir/reports/pmd/pmd.html"
-        }
     }
 }
 
-check.dependsOn 'checkstyle', 'pmd'
+pmd {
+    ignoreFailures = false
+    ruleSetFiles = files("${project.rootDir}/config/pmd/pmd-ruleset.xml")
+    ruleSets = []
+    reportsDir = file("$project.buildDir/reports/findbugs")
+}

--- a/java/libs/config/findbugs/exclude-filter.xml
+++ b/java/libs/config/findbugs/exclude-filter.xml
@@ -5,4 +5,9 @@
     <Method name="~json(Des|S)erializeUrlDevice"/>
     <Bug pattern="DM_STRING_CTOR"/>
   </Match>
+  <Match>
+    <Class name="org.physical_web.collection.PwPair"/>
+    <Method name="equals"/>
+    <Bug pattern="FE_FLOATING_POINT_EQUALITY"/>
+  </Match>
 </FindBugsFilter>

--- a/java/libs/src/main/java/org/physical_web/collection/PwPair.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PwPair.java
@@ -82,6 +82,6 @@ public class PwPair implements Comparable<PwPair> {
    * @return the comparison value.
    */
   public int compareTo(PwPair other) {
-    return new Double(getRank()).compareTo(other.getRank());
+    return Double.compare(getRank(), other.getRank());
   }
 }


### PR DESCRIPTION
Add ignoreFailures, effort, reportLevel back to findbugs config
* These were mistakenly removed in the last commit.

Change findbugs reportLevel to "low" (most verbose)
* It's confusing that "high" means "high confidence errors only".  So, "low" is correct if we want to detect more bugs.  Currently this only detects two more bugs so it seems worthwhile to leave it on.

Exclude findbugs floating point equality warning in PwPair.equals
* Comparing exact floating point values is what we want in this case since we just need the ranks to be well-ordered and don't care about floating point error.

Use the Double comparator in PwPair.compareTo to appease findbugs
* Avoids unnecessarily creating a new Double when comparing.

Remove unecessary checkstyle and pmd tasks, the plugins will create them
* Findbugs, checkstyle, and pmd all auto-create Main and Test tasks and add them as dependencies of the "check" task, so there's no need for us to do it.