### PR TITLE
Add URL group IDs in PwsResult

### DIFF
--- a/java/libs/src/main/java/org/physical_web/collection/PwsClient.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PwsClient.java
@@ -90,7 +90,7 @@ public class PwsClient {
           } catch (JSONException e) {
             continue;
           }
-          PwsResult pwsResult = new PwsResult(requestUrl, responseUrl);
+          PwsResult pwsResult = new PwsResult(requestUrl, responseUrl, null);
           pwsResultCallback.onPwsResult(pwsResult);
           foundUrls.add(pwsResult.getRequestUrl());
         }

--- a/java/libs/src/main/java/org/physical_web/collection/PwsResult.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PwsResult.java
@@ -21,15 +21,18 @@ package org.physical_web.collection;
 public class PwsResult {
   private String mRequestUrl;
   private String mSiteUrl;
+  private String mGroupId;
 
   /**
    * Construct a PwsResult.
    * @param requestUrl The request URL, as broadcasted by the device
    * @param siteUrl The site URL, as reported by PWS
+   * @param groupId The URL group ID, as reported by PWS
    */
-  PwsResult(String requestUrl, String siteUrl) {
+  PwsResult(String requestUrl, String siteUrl, String groupId) {
     mRequestUrl = requestUrl;
     mSiteUrl = siteUrl;
+    mGroupId = groupId;
   }
 
   /**
@@ -50,5 +53,15 @@ public class PwsResult {
    */
   public String getSiteUrl() {
     return mSiteUrl;
+  }
+
+  /**
+   * Fetches the URL group ID.
+   * The group ID is returned by the Physical Web Service and is used to group similar (but not
+   * necessarily identical) URLs.
+   * @return The URL group ID, may be null
+   */
+  public String getGroupId() {
+    return mGroupId;
   }
 }

--- a/java/libs/src/main/java/org/physical_web/collection/UrlGroup.java
+++ b/java/libs/src/main/java/org/physical_web/collection/UrlGroup.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.physical_web.collection;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A collection of similar URLs, the devices broadcasting those URLs, and associated metadata.
+ */
+public class UrlGroup implements Comparable<UrlGroup> {
+  private String mGroupId;
+  private List<PwPair> mPwPairs;
+
+  /**
+   * Construct a UrlGroup.
+   * @param groupId The URL group ID of this group.
+   */
+  public UrlGroup(String groupId) {
+    mGroupId = groupId;
+    mPwPairs = new ArrayList<>();
+  }
+
+  /**
+   * Gets the group ID for this group.
+   * @return Group ID
+   */
+  public String getGroupId() {
+    return mGroupId;
+  }
+
+  /**
+   * Add a PwPair to this group.
+   * @param pwPair The PwPair to add.
+   */
+  public void addPair(PwPair pwPair) {
+    mPwPairs.add(pwPair);
+  }
+
+  /**
+   * Get the top-ranked PwPair in this group.
+   * @return The top PwPair.
+   */
+  public PwPair getTopPair() {
+    return Collections.max(mPwPairs);
+  }
+
+  /**
+   * Unimplemented hash code method.
+   * @return 42.
+   */
+  @Override
+  public int hashCode() {
+    assert false : "hashCode not designed";
+    return 42;
+  }
+
+  /**
+   * Check if two UrlGroups are equal based on the ranks of their top pairs.
+   * @param other the UrlGroup to compare to.
+   * @return true if the top pairs are of equal rank.
+   */
+  @Override
+  public boolean equals(Object other) {
+    if (other instanceof UrlGroup) {
+      UrlGroup otherUrlGroup = (UrlGroup) other;
+      return getTopPair() == otherUrlGroup.getTopPair();
+    }
+    return false;
+  }
+
+  /**
+   * Compare two UrlGroups based on the ranks of their top pairs.
+   * @param other the UrlGroup to compare to.
+   * @return the comparison value.
+   */
+  @Override
+  public int compareTo(UrlGroup other) {
+    return getTopPair().compareTo(other.getTopPair());
+  }
+}

--- a/java/libs/src/test/java/org/physical_web/collection/PwPairTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/PwPairTest.java
@@ -33,7 +33,7 @@ public class PwPairTest {
   @Before
   public void setUp() {
     urlDevice1 = new SimpleUrlDevice(ID1, URL1);
-    pwsResult1 = new PwsResult(URL1, URL1);
+    pwsResult1 = new PwsResult(URL1, URL1, null);
     pwPair1 = new PwPair(urlDevice1, pwsResult1);
   }
 

--- a/java/libs/src/test/java/org/physical_web/collection/PwsResultTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/PwsResultTest.java
@@ -29,7 +29,7 @@ public class PwsResultTest {
 
   @Before
   public void setUp() {
-    pwsResult1 = new PwsResult(URL1, URL1);
+    pwsResult1 = new PwsResult(URL1, URL1, null);
   }
 
   @Test

--- a/java/libs/src/test/java/org/physical_web/collection/RankedDevice.java
+++ b/java/libs/src/test/java/org/physical_web/collection/RankedDevice.java
@@ -1,0 +1,42 @@
+package org.physical_web.collection;
+
+/**
+ * A mock UrlDevice with a configurable rank value.
+ */
+class RankedDevice implements UrlDevice {
+  private String mId;
+  private String mUrl;
+  private double mRank;
+
+  RankedDevice(String id, String url, double rank) {
+    mId = id;
+    mUrl = url;
+    mRank = rank;
+  }
+
+  public String getId() {
+    return mId;
+  }
+
+  public String getUrl() {
+    return mUrl;
+  }
+
+  public double getRank(PwsResult pwsResult) {
+    return mRank;
+  }
+
+  /**
+   * Utility method for constructing a PwPair with a RankedDevice.
+   * @param id URL device ID
+   * @param url Broadcast URL
+   * @param groupId URL group ID
+   * @param rank Rank value for this device
+   * @return New PwPair
+   */
+  public static PwPair createRankedPair(String id, String url, String groupId, double rank) {
+    UrlDevice urlDevice = new RankedDevice(id, url, rank);
+    PwsResult pwsResult = new PwsResult(url, url, groupId);
+    return new PwPair(urlDevice, pwsResult);
+  }
+}

--- a/java/libs/src/test/java/org/physical_web/collection/SimpleUrlDeviceTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/SimpleUrlDeviceTest.java
@@ -45,7 +45,7 @@ public class SimpleUrlDeviceTest {
 
   @Test
   public void getRankReturnsPointFive() {
-    PwsResult pwsResult = new PwsResult(URL1, URL1);
+    PwsResult pwsResult = new PwsResult(URL1, URL1, null);
     assertEquals(.5, urlDevice1.getRank(pwsResult), .0001);
   }
 }

--- a/java/libs/src/test/java/org/physical_web/collection/UrlGroupTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/UrlGroupTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.physical_web.collection;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * UrlGroup unit test class.
+ */
+public class UrlGroupTest {
+  private static final String ID1 = "id1";
+  private static final String ID2 = "id2";
+  private static final String URL1 = "http://physical-web.org/#a";
+  private static final String URL2 = "http://physical-web.org/#b";
+  private static final String GROUPID1 = "group1";
+  private static final double RANK1 = 0.5d;
+  private static final double RANK2 = 0.9d;
+
+  private PwPair pwPair1;
+  private PwPair pwPair2;
+
+  @Before
+  public void setUp() {
+    pwPair1 = RankedDevice.createRankedPair(ID1, URL1, GROUPID1, RANK1);
+    pwPair2 = RankedDevice.createRankedPair(ID2, URL2, GROUPID1, RANK2);
+  }
+
+  @Test
+  public void constructorCreatesProperObject() {
+    UrlGroup urlGroup = new UrlGroup(GROUPID1);
+    assertEquals(urlGroup.getGroupId(), GROUPID1);
+  }
+
+  @Test
+  public void addPairAndGetTopPairWorks() {
+    UrlGroup urlGroup = new UrlGroup(GROUPID1);
+    urlGroup.addPair(pwPair1);
+
+    PwPair pwPair = urlGroup.getTopPair();
+    assertEquals(pwPair.getUrlDevice().getId(), ID1);
+    assertEquals(pwPair.getUrlDevice().getUrl(), URL1);
+    assertEquals(pwPair.getPwsResult().getRequestUrl(), URL1);
+    assertEquals(pwPair.getPwsResult().getSiteUrl(), URL1);
+    assertEquals(pwPair.getPwsResult().getGroupId(), GROUPID1);
+  }
+
+  @Test
+  public void addPairTwiceAndGetTopPairWorks() {
+    UrlGroup urlGroup = new UrlGroup(GROUPID1);
+    urlGroup.addPair(pwPair1);
+    urlGroup.addPair(pwPair2); // higher rank
+
+    PwPair pwPair = urlGroup.getTopPair();
+    assertEquals(pwPair.getUrlDevice().getId(), ID2);
+  }
+}


### PR DESCRIPTION
Add groupId field in PwsResult (serialization treats it as optional)
Add UrlGroup container for returning grouped device/metadata pairs
Add getUrlGroupsSortedByRank (groups are compared/sorted based on their top-ranked PwPairs)
Move RankedDevice mock object out of PhysicalWebCollectionTest, it is also used by UrlGroupTest