### PR TITLE
Don't send empty requests to PWS

### DIFF
--- a/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
@@ -348,7 +348,9 @@ public class PhysicalWebCollection {
         pwsResultCallback.onPwsResultError(urls, httpResponseCode, e);
       }
     };
-    mPwsClient.resolve(newUrls, augmentedCallback);
+    if (newUrls.size() > 0) {
+      mPwsClient.resolve(newUrls, augmentedCallback);
+    }
   }
 
 


### PR DESCRIPTION
If there are no new URLs to get metadata for, don't send a request
to PWS.