### PR TITLE
Clean up groupid functionality in physical web library

### DIFF
--- a/java/libs/src/integrationTest/java/org/physical_web/collection/IntegrationTest.java
+++ b/java/libs/src/integrationTest/java/org/physical_web/collection/IntegrationTest.java
@@ -31,19 +31,6 @@ import java.util.concurrent.TimeUnit;
 public class IntegrationTest {
   private PhysicalWebCollection physicalWebCollection;
 
-  private static class RankedDevice extends SimpleUrlDevice {
-    private double mRank;
-
-    RankedDevice(String id, String url, double rank) {
-      super(id, url);
-      mRank = rank;
-    }
-
-    public double getRank(PwsResult pwsResult) {
-      return mRank;
-    }
-  }
-
   private class FetchPwsResultsTask {
     private int mNumExpected;
     private Semaphore mMutex;

--- a/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
@@ -280,19 +280,17 @@ public class PhysicalWebCollection {
     Map<String, UrlGroup> pwGroupMap = new HashMap<>();
     for (PwPair pwPair : sortedPwPairs) {
       PwsResult pwsResult = pwPair.getPwsResult();
-      if (pwsResult != null) {
-        String groupId = pwsResult.getGroupId();
-        if (groupId != null && !groupId.equals("")) {
-          // Create the group if it doesn't exist
-          UrlGroup urlGroup = pwGroupMap.get(groupId);
-          if (urlGroup == null) {
-            urlGroup = new UrlGroup(groupId);
-            pwGroupMap.put(groupId, urlGroup);
-          }
-
-          // Add the pair to this group
-          urlGroup.addPair(pwPair);
+      String groupId = pwsResult.getGroupId();
+      if (groupId != null && !groupId.equals("")) {
+        // Create the group if it doesn't exist
+        UrlGroup urlGroup = pwGroupMap.get(groupId);
+        if (urlGroup == null) {
+          urlGroup = new UrlGroup(groupId);
+          pwGroupMap.put(groupId, urlGroup);
         }
+
+        // Add the pair to this group
+        urlGroup.addPair(pwPair);
       }
     }
 

--- a/java/libs/src/main/java/org/physical_web/collection/PwPair.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PwPair.java
@@ -57,33 +57,59 @@ public class PwPair implements Comparable<PwPair> {
   }
 
   /**
-   * Unimplemented hash code method.
-   * @return 42.
+   * Return a hash code for this PwPair.
+   * @return hash code
    */
+  @Override
   public int hashCode() {
-    assert false : "hashCode not designed";
-    return 42;
+    int hash = 1;
+    hash = hash * 31 + Double.valueOf(getRank()).hashCode();
+    hash = hash * 31 + mUrlDevice.hashCode();
+    hash = hash * 31 + mPwsResult.hashCode();
+    return hash;
   }
 
   /**
-   * Check if two PwPairs are equal based on rank.
+   * Check if two PwPairs are equal.
    * @param other the PwPair to compare to.
-   * @return true if the ranks are equal.
+   * @return true if the PwPairs are equal.
    */
+  @Override
   public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+
     if (other instanceof PwPair) {
       PwPair otherPwPair = (PwPair) other;
-      return getRank() == otherPwPair.getRank();
+      return getRank() == otherPwPair.getRank() &&
+          mUrlDevice.equals(otherPwPair.mUrlDevice) &&
+          mPwsResult.equals(otherPwPair.mPwsResult);
     }
     return false;
   }
 
   /**
-   * Compare two PwPairs based on rank.
+   * Compare two PwPairs based on rank, breaking ties by comparing UrlDevice and PwsResult.
    * @param other the PwPair to compare to.
    * @return the comparison value.
    */
+  @Override
   public int compareTo(PwPair other) {
-    return Double.compare(getRank(), other.getRank());
+    if (this == other) {
+      return 0;
+    }
+
+    int compareValue = Double.compare(getRank(), other.getRank());
+    if (compareValue != 0) {
+      return compareValue;
+    }
+
+    compareValue = mUrlDevice.compareTo(other.mUrlDevice);
+    if (compareValue != 0) {
+      return compareValue;
+    }
+
+    return mPwsResult.compareTo(other.mPwsResult);
   }
 }

--- a/java/libs/src/main/java/org/physical_web/collection/PwsResult.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PwsResult.java
@@ -18,7 +18,7 @@ package org.physical_web.collection;
 /**
  * Metadata returned from the Physical Web Service for a single URL.
  */
-public class PwsResult {
+public class PwsResult implements Comparable<PwsResult> {
   private String mRequestUrl;
   private String mSiteUrl;
   private String mGroupId;
@@ -63,5 +63,64 @@ public class PwsResult {
    */
   public String getGroupId() {
     return mGroupId;
+  }
+
+  /**
+   * Return a hash code for this PwsResult.
+   * @return hash code
+   */
+  @Override
+  public int hashCode() {
+    int hash = 1;
+    hash = hash * 31 + mRequestUrl.hashCode();
+    hash = hash * 31 + mSiteUrl.hashCode();
+    hash = hash * 31 + ((mGroupId == null) ? 0 : mGroupId.hashCode());
+    return hash;
+  }
+
+  /**
+   * Check if two PwsResults are equal.
+   * @param other the PwsResult to compare to.
+   * @return true if the PwsResults are equal.
+   */
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+
+    if (other instanceof PwsResult) {
+      PwsResult otherPwsResult = (PwsResult) other;
+
+      return Utils.nullSafeCompare(mGroupId, otherPwsResult.mGroupId) == 0 &&
+          mRequestUrl.equals(otherPwsResult.mRequestUrl) &&
+          mSiteUrl.equals(otherPwsResult.mSiteUrl);
+    }
+    return false;
+  }
+
+  /**
+   * Compare two PwsResults based on request URL alphabetical ordering, breaking ties by comparing
+   * site URL and group ID.
+   * @param other the PwsResult to compare to.
+   * @return the comparison value.
+   */
+  @Override
+  public int compareTo(PwsResult other) {
+    if (this == other) {
+      return 0;
+    }
+
+    int compareValue = mRequestUrl.compareTo(other.mRequestUrl);
+    if (compareValue != 0) {
+      return compareValue;
+    }
+
+    compareValue = mSiteUrl.compareTo(other.mSiteUrl);
+    if (compareValue != 0) {
+      return compareValue;
+    }
+
+    return Utils.nullSafeCompare(mGroupId, other.mGroupId);
   }
 }

--- a/java/libs/src/main/java/org/physical_web/collection/SimpleUrlDevice.java
+++ b/java/libs/src/main/java/org/physical_web/collection/SimpleUrlDevice.java
@@ -19,8 +19,8 @@ package org.physical_web.collection;
  * A basic implementation of the UrlDevice interface.
  */
 public class SimpleUrlDevice implements UrlDevice {
-  private String mId;
-  private String mUrl;
+  protected String mId;
+  protected String mUrl;
 
   /**
    * Construct a SimpleUrlDevice.
@@ -38,6 +38,7 @@ public class SimpleUrlDevice implements UrlDevice {
    * one real world device is broadcasting multiple URLs.
    * @return The ID of the device.
    */
+  @Override
   public String getId() {
     return mId;
   }
@@ -46,6 +47,7 @@ public class SimpleUrlDevice implements UrlDevice {
    * Fetches the URL broadcasted by the device.
    * @return The broadcasted URL.
    */
+  @Override
   public String getUrl() {
     return mUrl;
   }
@@ -56,7 +58,58 @@ public class SimpleUrlDevice implements UrlDevice {
    *        for the url broadcasted by this UrlDevice.
    * @return .5 (at the moment we don't have anything by which to judge rank)
    */
+  @Override
   public double getRank(PwsResult pwsResult) {
     return .5;
+  }
+
+  /**
+   * Return a hash code for this SimpleUrlDevice.
+   * @return hash code
+   */
+  @Override
+  public int hashCode() {
+    int hash = 1;
+    hash = hash * 31 + mId.hashCode();
+    hash = hash * 31 + mUrl.hashCode();
+    return hash;
+  }
+
+  /**
+   * Check if two UrlDevices are equal.
+   * @param other the UrlDevice to compare to.
+   * @return true if the UrlDevices are equal
+   */
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+
+    if (other instanceof UrlDevice) {
+      UrlDevice otherUrlDevice = (UrlDevice) other;
+      return mId.equals(otherUrlDevice.getId()) &&
+          mUrl.equals(otherUrlDevice.getUrl());
+    }
+    return false;
+  }
+
+  /**
+   * Compare two UrlDevices based on device ID, breaking ties by comparing broadcast URL.
+   * @param other the UrlDevice to compare to.
+   * @return the comparison value.
+   */
+  @Override
+  public int compareTo(UrlDevice other) {
+    if (this == other) {
+      return 0;
+    }
+
+    int compareValue = mId.compareTo(other.getId());
+    if (compareValue != 0) {
+      return compareValue;
+    }
+
+    return mUrl.compareTo(other.getUrl());
   }
 }

--- a/java/libs/src/main/java/org/physical_web/collection/UrlDevice.java
+++ b/java/libs/src/main/java/org/physical_web/collection/UrlDevice.java
@@ -18,7 +18,7 @@ package org.physical_web.collection;
 /**
  * The interface defining a Physical Web URL device.
  */
-public interface UrlDevice {
+public interface UrlDevice extends Comparable<UrlDevice> {
   /**
    * Fetches the ID of the UrlDevice.
    * The ID should be unique across UrlDevices.  This should even be the case when

--- a/java/libs/src/main/java/org/physical_web/collection/UrlGroup.java
+++ b/java/libs/src/main/java/org/physical_web/collection/UrlGroup.java
@@ -78,18 +78,25 @@ public class UrlGroup implements Comparable<UrlGroup> {
   public boolean equals(Object other) {
     if (other instanceof UrlGroup) {
       UrlGroup otherUrlGroup = (UrlGroup) other;
-      return getTopPair() == otherUrlGroup.getTopPair();
+      return getTopPair().equals(otherUrlGroup.getTopPair()) &&
+          getGroupId().equals(otherUrlGroup.getGroupId());
     }
     return false;
   }
 
   /**
    * Compare two UrlGroups based on the ranks of their top pairs.
+   * Ties are broken by alphabetical comparison of groupid strings.
    * @param other the UrlGroup to compare to.
    * @return the comparison value.
    */
   @Override
   public int compareTo(UrlGroup other) {
-    return getTopPair().compareTo(other.getTopPair());
+    int compareValue = getTopPair().compareTo(other.getTopPair());
+    if (compareValue != 0) {
+      return compareValue;
+    }
+
+    return getGroupId().compareTo(other.getGroupId());
   }
 }

--- a/java/libs/src/main/java/org/physical_web/collection/UrlGroup.java
+++ b/java/libs/src/main/java/org/physical_web/collection/UrlGroup.java
@@ -18,13 +18,14 @@ package org.physical_web.collection;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.PriorityQueue;
 
 /**
  * A collection of similar URLs, the devices broadcasting those URLs, and associated metadata.
  */
 public class UrlGroup implements Comparable<UrlGroup> {
   private String mGroupId;
-  private List<PwPair> mPwPairs;
+  private PriorityQueue<PwPair> mPwPairs;
 
   /**
    * Construct a UrlGroup.
@@ -32,7 +33,7 @@ public class UrlGroup implements Comparable<UrlGroup> {
    */
   public UrlGroup(String groupId) {
     mGroupId = groupId;
-    mPwPairs = new ArrayList<>();
+    mPwPairs = new PriorityQueue<>(1, Collections.reverseOrder());
   }
 
   /**
@@ -56,7 +57,7 @@ public class UrlGroup implements Comparable<UrlGroup> {
    * @return The top PwPair.
    */
   public PwPair getTopPair() {
-    return Collections.max(mPwPairs, Collections.reverseOrder());
+    return mPwPairs.peek();
   }
 
   /**

--- a/java/libs/src/main/java/org/physical_web/collection/UrlGroup.java
+++ b/java/libs/src/main/java/org/physical_web/collection/UrlGroup.java
@@ -56,31 +56,45 @@ public class UrlGroup implements Comparable<UrlGroup> {
    * @return The top PwPair.
    */
   public PwPair getTopPair() {
-    return Collections.max(mPwPairs);
+    return Collections.max(mPwPairs, Collections.reverseOrder());
   }
 
   /**
-   * Unimplemented hash code method.
-   * @return 42.
+   * Return a hash code for this UrlGroup.
+   * @return hash code
    */
   @Override
   public int hashCode() {
-    assert false : "hashCode not designed";
-    return 42;
+    int hash = 1;
+    hash = hash * 31 + ((mGroupId == null) ? 0 : mGroupId.hashCode());
+    hash = hash * 31 + mPwPairs.hashCode();
+    return hash;
   }
 
   /**
-   * Check if two UrlGroups are equal based on the ranks of their top pairs.
+   * Check if two UrlGroups are equal.
    * @param other the UrlGroup to compare to.
    * @return true if the top pairs are of equal rank.
    */
   @Override
   public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+
     if (other instanceof UrlGroup) {
       UrlGroup otherUrlGroup = (UrlGroup) other;
-      return getTopPair().equals(otherUrlGroup.getTopPair()) &&
-          getGroupId().equals(otherUrlGroup.getGroupId());
+      if (mPwPairs.size() == otherUrlGroup.mPwPairs.size() &&
+          mGroupId.equals(otherUrlGroup.mGroupId)) {
+        // don't consider order when comparing lists
+        List<PwPair> myPairs = new ArrayList<>(mPwPairs);
+        List<PwPair> otherPairs = new ArrayList<>(otherUrlGroup.mPwPairs);
+        Collections.sort(myPairs);
+        Collections.sort(otherPairs);
+        return myPairs.equals(otherPairs);
+      }
     }
+
     return false;
   }
 
@@ -92,11 +106,16 @@ public class UrlGroup implements Comparable<UrlGroup> {
    */
   @Override
   public int compareTo(UrlGroup other) {
-    int compareValue = getTopPair().compareTo(other.getTopPair());
+    if (this == other) {
+      return 0;
+    }
+
+    int compareValue = Utils.nullSafeCompare(getTopPair(), other.getTopPair());
     if (compareValue != 0) {
       return compareValue;
     }
 
-    return getGroupId().compareTo(other.getGroupId());
+    return Utils.nullSafeCompare(mGroupId, other.mGroupId);
   }
+
 }

--- a/java/libs/src/main/java/org/physical_web/collection/Utils.java
+++ b/java/libs/src/main/java/org/physical_web/collection/Utils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.physical_web.collection;
+
+/**
+ * Utility methods for the Physical Web library.
+ */
+public class Utils {
+  /**
+   * Compare two nullable comparables, preferring any non-null value over null.
+   * @param o1 first object to compare
+   * @param o2 second object to compare
+   * @param <T> a type that implements Comparable&lt;T&gt;
+   * @return comparison value
+   */
+  public static <T extends Comparable<T>> int nullSafeCompare(T o1, T o2) {
+    if (o1 == o2) {
+      return 0;
+    }
+    if (o1 == null) {
+      return -1;
+    }
+    if (o2 == null) {
+      return 1;
+    }
+    return o1.compareTo(o2);
+  }
+}

--- a/java/libs/src/test/java/org/physical_web/collection/PwPairTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/PwPairTest.java
@@ -25,21 +25,88 @@ import org.junit.Test;
  */
 public class PwPairTest {
   private static final String ID1 = "id1";
+  private static final String ID2 = "id2";
   private static final String URL1 = "http://example.com";
-  private SimpleUrlDevice urlDevice1;
-  private PwsResult pwsResult1;
-  private PwPair pwPair1;
+  private static final String URL2 = "http://physical-web.org";
+  private static final String GROUPID1 = "group1";
+  private static final double RANK1 = 0.5d;
+  private static final double RANK2 = 0.9d;
+  private SimpleUrlDevice mUrlDevice1;
+  private PwsResult mPwsResult1;
+  private PwPair mPwPair1;
 
   @Before
   public void setUp() {
-    urlDevice1 = new SimpleUrlDevice(ID1, URL1);
-    pwsResult1 = new PwsResult(URL1, URL1, null);
-    pwPair1 = new PwPair(urlDevice1, pwsResult1);
+    mUrlDevice1 = new SimpleUrlDevice(ID1, URL1);
+    mPwsResult1 = new PwsResult(URL1, URL1, null);
+    mPwPair1 = new PwPair(mUrlDevice1, mPwsResult1);
   }
 
   @Test
   public void constructorCreatesProperObject() {
-    assertEquals(urlDevice1, pwPair1.getUrlDevice());
-    assertEquals(pwsResult1, pwPair1.getPwsResult());
+    assertEquals(mUrlDevice1, mPwPair1.getUrlDevice());
+    assertEquals(mPwsResult1, mPwPair1.getPwsResult());
+  }
+
+  @Test
+  public void pairIsEqualToItself() {
+    assertEquals(mPwPair1, mPwPair1);
+  }
+
+  @Test
+  public void alikePairsAreEqual() {
+    UrlDevice urlDevice2 = new SimpleUrlDevice(ID1, URL1);
+    PwsResult pwsResult2 = new PwsResult(URL1, URL1, null);
+    UrlDevice urlDevice3 = new RankedDevice(ID1, URL1, RANK1);
+    PwPair pwPair2 = new PwPair(urlDevice2, pwsResult2); // identical PwPair
+    PwPair pwPair3 = new PwPair(urlDevice3, mPwsResult1); // same info, but uses a RankedDevice
+    assertEquals(mPwPair1, pwPair2);
+    assertEquals(mPwPair1, pwPair3);
+  }
+
+  @Test
+  public void unalikePairsAreNotEqual() {
+    PwsResult pwsResult2 = new PwsResult(URL1, URL2, GROUPID1);
+    UrlDevice urlDevice2 = new SimpleUrlDevice(ID2, URL1);
+    UrlDevice urlDevice3 = new RankedDevice(ID1, URL1, RANK2);
+    PwPair pwPair2 = new PwPair(mUrlDevice1, pwsResult2); // different URL metadata
+    PwPair pwPair3 = new PwPair(urlDevice2, mPwsResult1); // different device
+    PwPair pwPair4 = new PwPair(urlDevice3, mPwsResult1); // different rank
+    assertNotEquals(mPwPair1, pwPair2);
+    assertNotEquals(mPwPair1, pwPair3);
+    assertNotEquals(mPwPair1, pwPair4);
+  }
+
+  @Test
+  public void comparePairToItselfReturnsZero() {
+    assertEquals(mPwPair1.compareTo(mPwPair1), 0);
+  }
+
+  @Test
+  public void comparePairToAlikePairReturnsZero() {
+    UrlDevice urlDevice2 = new SimpleUrlDevice(ID1, URL1);
+    PwsResult pwsResult2 = new PwsResult(URL1, URL1, null);
+    UrlDevice urlDevice3 = new RankedDevice(ID1, URL1, RANK1);
+    PwPair pwPair2 = new PwPair(urlDevice2, pwsResult2); // identical PwPair
+    PwPair pwPair3 = new PwPair(urlDevice3, mPwsResult1); // same info, but uses a RankedDevice
+    assertEquals(mPwPair1.compareTo(pwPair2), 0);
+    assertEquals(mPwPair1.compareTo(pwPair3), 0);
+    assertEquals(pwPair3.compareTo(mPwPair1), 0); // exercise null checks with reverse compare
+  }
+
+  @Test
+  public void comparePairToUnalikePairReturnsNonZero() {
+    UrlDevice urlDevice2 = new SimpleUrlDevice(ID2, URL1);
+    UrlDevice urlDevice3 = new RankedDevice(ID1, URL1, RANK2);
+    PwsResult pwsResult2 = new PwsResult(URL1, URL1, GROUPID1);
+    PwPair pwPair2 = new PwPair(urlDevice2, mPwsResult1);
+    PwPair pwPair3 = new PwPair(urlDevice3, mPwsResult1);
+    PwPair pwPair4 = new PwPair(mUrlDevice1, pwsResult2);
+    assertTrue(mPwPair1.compareTo(pwPair2) < 0); // "ID1" < "ID2"
+    assertTrue(mPwPair1.compareTo(pwPair3) < 0); // 0.5 < 0.9
+    assertTrue(mPwPair1.compareTo(pwPair4) < 0); // null < "group1"
+    assertTrue(pwPair2.compareTo(mPwPair1) > 0);
+    assertTrue(pwPair3.compareTo(mPwPair1) > 0);
+    assertTrue(pwPair4.compareTo(mPwPair1) > 0);
   }
 }

--- a/java/libs/src/test/java/org/physical_web/collection/PwsResultTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/PwsResultTest.java
@@ -15,7 +15,7 @@
  */
 package org.physical_web.collection;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -25,16 +25,65 @@ import org.junit.Test;
  */
 public class PwsResultTest {
   private static final String URL1 = "http://example.com";
-  private PwsResult pwsResult1;
+  private static final String URL2 = "http://physical-web.org";
+  private static final String GROUPID1 = "group1";
+  private PwsResult mPwsResult1;
+  private PwsResult mPwsResult2;
 
   @Before
   public void setUp() {
-    pwsResult1 = new PwsResult(URL1, URL1, null);
+    mPwsResult1 = new PwsResult(URL1, URL1, null);
+    mPwsResult2 = new PwsResult(URL1, URL1, GROUPID1);
   }
 
   @Test
   public void constructorCreatesProperObject() {
-    assertEquals(pwsResult1.getRequestUrl(), URL1);
-    assertEquals(pwsResult1.getSiteUrl(), URL1);
+    assertEquals(mPwsResult1.getRequestUrl(), URL1);
+    assertEquals(mPwsResult1.getSiteUrl(), URL1);
+  }
+
+  @Test
+  public void resultIsEqualToItself() {
+    assertEquals(mPwsResult1, mPwsResult1);
+  }
+
+  @Test
+  public void alikeResultsAreEqual() {
+    PwsResult pwsResult3 = new PwsResult(URL1, URL1, null); // identical to mPwsResult1
+    PwsResult pwsResult4 = new PwsResult(URL1, URL1, GROUPID1); // identical to mPwsResult2
+    assertEquals(mPwsResult1, pwsResult3);
+    assertEquals(mPwsResult2, pwsResult4);
+  }
+
+  @Test
+  public void unalikeResultsAreNotEqual() {
+    PwsResult pwsResult3 = new PwsResult(URL2, URL2, null);
+    assertNotEquals(mPwsResult1, mPwsResult2); // groupid mismatch
+    assertNotEquals(mPwsResult2, mPwsResult1); // groupid mismatch (reverse comparison)
+    assertNotEquals(mPwsResult1, pwsResult3); // URL mismatch
+  }
+
+  @Test
+  public void compareResultToItselfReturnsZero() {
+    assertEquals(mPwsResult1.compareTo(mPwsResult1), 0);
+    assertEquals(mPwsResult2.compareTo(mPwsResult2), 0);
+  }
+
+  @Test
+  public void compareResultToAlikeResultReturnsZero() {
+    PwsResult pwsResult3 = new PwsResult(URL1, URL1, null); // identical to mPwsResult1
+    PwsResult pwsResult4 = new PwsResult(URL1, URL1, GROUPID1); // identical to mPwsResult2
+    assertEquals(mPwsResult1.compareTo(pwsResult3), 0);
+    assertEquals(pwsResult3.compareTo(mPwsResult1), 0);
+    assertEquals(mPwsResult2.compareTo(pwsResult4), 0);
+  }
+
+  @Test
+  public void compareResultToUnalikeResultReturnsNonZero() {
+    PwsResult pwsResult3 = new PwsResult(URL2, URL2, null);
+    assertTrue(mPwsResult1.compareTo(mPwsResult2) < 0); // null < "group1"
+    assertTrue(mPwsResult2.compareTo(mPwsResult1) > 0);
+    assertTrue(mPwsResult1.compareTo(pwsResult3) < 0); // "example.com" < "physical-web.org"
+    assertTrue(pwsResult3.compareTo(mPwsResult1) > 0);
   }
 }

--- a/java/libs/src/test/java/org/physical_web/collection/RankedDevice.java
+++ b/java/libs/src/test/java/org/physical_web/collection/RankedDevice.java
@@ -3,27 +3,27 @@ package org.physical_web.collection;
 /**
  * A mock UrlDevice with a configurable rank value.
  */
-class RankedDevice implements UrlDevice {
-  private String mId;
-  private String mUrl;
+public class RankedDevice extends SimpleUrlDevice {
   private double mRank;
 
-  RankedDevice(String id, String url, double rank) {
-    mId = id;
-    mUrl = url;
+  public RankedDevice(String id, String url, double rank) {
+    super(id, url);
     mRank = rank;
   }
 
-  public String getId() {
-    return mId;
-  }
-
-  public String getUrl() {
-    return mUrl;
-  }
-
+  @Override
   public double getRank(PwsResult pwsResult) {
     return mRank;
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return super.equals(other);
   }
 
   /**

--- a/java/libs/src/test/java/org/physical_web/collection/SimpleUrlDeviceTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/SimpleUrlDeviceTest.java
@@ -25,27 +25,95 @@ import org.junit.Test;
  */
 public class SimpleUrlDeviceTest {
   private static final String ID1 = "id1";
+  private static final String ID2 = "id2";
   private static final String URL1 = "http://example.com";
-  private SimpleUrlDevice urlDevice1;
+  private static final String URL2 = "http://physical-web.org";
+  private static final double RANK1 = 0.5d;
+  private static final double RANK2 = 0.9d;
+  private SimpleUrlDevice mUrlDevice1;
 
   @Before
   public void setUp() {
-    urlDevice1 = new SimpleUrlDevice(ID1, URL1);
+    mUrlDevice1 = new SimpleUrlDevice(ID1, URL1);
   }
 
   @Test
   public void getIdReturnsId() {
-    assertEquals(urlDevice1.getId(), ID1);
+    assertEquals(mUrlDevice1.getId(), ID1);
   }
 
   @Test
   public void getUrlReturnsUrl() {
-    assertEquals(urlDevice1.getUrl(), URL1);
+    assertEquals(mUrlDevice1.getUrl(), URL1);
   }
 
   @Test
   public void getRankReturnsPointFive() {
     PwsResult pwsResult = new PwsResult(URL1, URL1, null);
-    assertEquals(.5, urlDevice1.getRank(pwsResult), .0001);
+    assertEquals(.5, mUrlDevice1.getRank(pwsResult), .0001);
+  }
+
+  @Test
+  public void deviceIsEqualToItself() {
+    assertEquals(mUrlDevice1, mUrlDevice1);
+  }
+
+  @Test
+  public void alikeDevicesAreEqual() {
+    SimpleUrlDevice urlDevice2 = new SimpleUrlDevice(ID1, URL1);
+    assertEquals(mUrlDevice1, urlDevice2);
+  }
+
+  @Test
+  public void devicesWithDifferentClassButSameInfoAreEqual() {
+    UrlDevice simpleUrlDevice = new SimpleUrlDevice(ID1, URL1);
+    UrlDevice rankedDevice = new RankedDevice(ID1, URL1, RANK1);
+    assertEquals(rankedDevice, simpleUrlDevice);
+    assertEquals(simpleUrlDevice, rankedDevice);
+  }
+
+  @Test
+  public void devicesWithDifferentRankButSameInfoAreEqual() {
+    UrlDevice urlDevice2 = new RankedDevice(ID1, URL1, RANK2); // different rank
+    assertEquals(mUrlDevice1, urlDevice2); // equals should not consider rank
+  }
+
+  @Test
+  public void unalikeDevicesAreNotEqual() {
+    SimpleUrlDevice urlDevice2 = new SimpleUrlDevice(ID1, URL2); // same id, different url
+    SimpleUrlDevice urlDevice3 = new SimpleUrlDevice(ID2, URL1); // same url, different id
+    assertNotEquals(mUrlDevice1, urlDevice2);
+    assertNotEquals(mUrlDevice1, urlDevice3);
+  }
+
+  @Test
+  public void compareDeviceToItselfReturnsZero() {
+    assertEquals(mUrlDevice1.compareTo(mUrlDevice1), 0);
+  }
+
+  @Test
+  public void compareDeviceToAlikeDeviceReturnsZero() {
+    UrlDevice urlDevice2 = new SimpleUrlDevice(ID1, URL1);
+    UrlDevice urlDevice3 = new RankedDevice(ID1, URL1, RANK1);
+    assertEquals(mUrlDevice1.compareTo(urlDevice2), 0); // identical device
+    assertEquals(mUrlDevice1.compareTo(urlDevice3), 0); // same info, but uses a RankedDevice
+    assertEquals(urlDevice3.compareTo(mUrlDevice1), 0); // reverse comparison
+  }
+
+  @Test
+  public void compareDeviceWithDifferentRankReturnsZero() {
+    UrlDevice urlDevice2 = new RankedDevice(ID1, URL1, RANK2); // different rank
+    assertEquals(mUrlDevice1.compareTo(urlDevice2), 0); // compareTo should not consider rank
+    assertEquals(urlDevice2.compareTo(mUrlDevice1), 0);
+  }
+
+  @Test
+  public void compareDeviceToUnalikeDeviceReturnsNonZero() {
+    UrlDevice urlDevice2 = new SimpleUrlDevice(ID2, URL1); // different device ID
+    UrlDevice urlDevice3 = new SimpleUrlDevice(ID1, URL2); // different URL
+    assertTrue(mUrlDevice1.compareTo(urlDevice2) < 0); // "id1" < "id2"
+    assertTrue(urlDevice2.compareTo(mUrlDevice1) > 0);
+    assertTrue(mUrlDevice1.compareTo(urlDevice3) < 0); // "example.com" < "physical-web.org"
+    assertTrue(urlDevice3.compareTo(mUrlDevice1) > 0);
   }
 }

--- a/java/libs/src/test/java/org/physical_web/collection/UrlGroupTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/UrlGroupTest.java
@@ -29,16 +29,17 @@ public class UrlGroupTest {
   private static final String URL1 = "http://physical-web.org/#a";
   private static final String URL2 = "http://physical-web.org/#b";
   private static final String GROUPID1 = "group1";
+  private static final String GROUPID2 = "group2";
   private static final double RANK1 = 0.5d;
   private static final double RANK2 = 0.9d;
 
-  private PwPair pwPair1;
-  private PwPair pwPair2;
+  private PwPair mPwPair1;
+  private PwPair mPwPair2;
 
   @Before
   public void setUp() {
-    pwPair1 = RankedDevice.createRankedPair(ID1, URL1, GROUPID1, RANK1);
-    pwPair2 = RankedDevice.createRankedPair(ID2, URL2, GROUPID1, RANK2);
+    mPwPair1 = RankedDevice.createRankedPair(ID1, URL1, GROUPID1, RANK1);
+    mPwPair2 = RankedDevice.createRankedPair(ID2, URL2, GROUPID1, RANK2);
   }
 
   @Test
@@ -50,7 +51,7 @@ public class UrlGroupTest {
   @Test
   public void addPairAndGetTopPairWorks() {
     UrlGroup urlGroup = new UrlGroup(GROUPID1);
-    urlGroup.addPair(pwPair1);
+    urlGroup.addPair(mPwPair1);
 
     PwPair pwPair = urlGroup.getTopPair();
     assertEquals(pwPair.getUrlDevice().getId(), ID1);
@@ -63,10 +64,100 @@ public class UrlGroupTest {
   @Test
   public void addPairTwiceAndGetTopPairWorks() {
     UrlGroup urlGroup = new UrlGroup(GROUPID1);
-    urlGroup.addPair(pwPair1);
-    urlGroup.addPair(pwPair2); // higher rank
+    urlGroup.addPair(mPwPair1);
+    urlGroup.addPair(mPwPair2); // higher rank
 
     PwPair pwPair = urlGroup.getTopPair();
     assertEquals(pwPair.getUrlDevice().getId(), ID2);
+  }
+
+  @Test
+  public void groupIsEqualToItself() {
+    UrlGroup urlGroup1 = new UrlGroup(GROUPID1);
+    assertEquals(urlGroup1, urlGroup1);
+  }
+
+  @Test
+  public void alikeEmptyGroupsAreEqual() {
+    UrlGroup urlGroup1 = new UrlGroup(GROUPID1);
+    UrlGroup urlGroup2 = new UrlGroup(GROUPID1); // same groupid
+    assertEquals(urlGroup1, urlGroup2);
+  }
+
+  @Test
+  public void unalikeEmptyGroupsAreNotEqual() {
+    UrlGroup urlGroup1 = new UrlGroup(GROUPID1);
+    UrlGroup urlGroup2 = new UrlGroup(GROUPID2); // different groupid
+    assertNotEquals(urlGroup1, urlGroup2);
+  }
+
+  @Test
+  public void alikeGroupsAreEqual() {
+    UrlGroup urlGroup1 = new UrlGroup(GROUPID1);
+    UrlGroup urlGroup2 = new UrlGroup(GROUPID1);
+    urlGroup1.addPair(mPwPair1);
+    urlGroup1.addPair(mPwPair2);
+    urlGroup2.addPair(mPwPair2); // add the pairs in a different order
+    urlGroup2.addPair(mPwPair1);
+    assertEquals(urlGroup1, urlGroup2);
+  }
+
+  @Test
+  public void unalikeGroupsAreNotEqual() {
+    UrlGroup urlGroup1 = new UrlGroup(GROUPID1);
+    UrlGroup urlGroup2 = new UrlGroup(GROUPID1); // same groupid
+    UrlGroup urlGroup3 = new UrlGroup(GROUPID2); // different groupid
+    PwPair pwPair1 = RankedDevice.createRankedPair(ID1, URL1, GROUPID1, RANK1);
+    PwPair pwPair2 = RankedDevice.createRankedPair(ID2, URL2, GROUPID1, RANK1);
+    PwPair pwPair3 = RankedDevice.createRankedPair(ID1, URL1, GROUPID2, RANK1);
+    urlGroup1.addPair(pwPair1);
+    urlGroup2.addPair(pwPair2);
+    urlGroup3.addPair(pwPair3);
+    assertNotEquals(urlGroup1, urlGroup2); // same groupid, different URLs
+    assertNotEquals(urlGroup1, urlGroup3); // different groupid, same URLs
+    urlGroup1.addPair(pwPair2);
+    assertNotEquals(urlGroup1, urlGroup2); // urlGroup1 has two items, urlGroup2 has only one
+  }
+
+  @Test
+  public void compareGroupToItselfReturnsZero() {
+    UrlGroup urlGroup1 = new UrlGroup(GROUPID1);
+    assertEquals(urlGroup1.compareTo(urlGroup1), 0); // compare empty group to itself
+    urlGroup1.addPair(mPwPair1);
+    assertEquals(urlGroup1.compareTo(urlGroup1), 0); // compare non-empty group to itself
+  }
+
+  @Test
+  public void compareGroupToAlikeGroupReturnsZero() {
+    UrlGroup urlGroup1 = new UrlGroup(GROUPID1);
+    UrlGroup urlGroup2 = new UrlGroup(GROUPID1);
+    assertEquals(urlGroup1.compareTo(urlGroup2), 0); // compare identical empty groups
+    urlGroup1.addPair(mPwPair1); // add pair 1 to both
+    urlGroup2.addPair(mPwPair1);
+    assertEquals(urlGroup1.compareTo(urlGroup2), 0); // compare identical groups with one pair
+  }
+
+  @Test
+  public void compareGroupToAlikeGroupWithDifferentOrderReturnsZero() {
+    UrlGroup urlGroup1 = new UrlGroup(GROUPID1);
+    UrlGroup urlGroup2 = new UrlGroup(GROUPID1);
+    urlGroup1.addPair(mPwPair1); // add pair1, then pair2
+    urlGroup1.addPair(mPwPair2);
+    urlGroup2.addPair(mPwPair2); // add pair2, then pair1
+    urlGroup2.addPair(mPwPair1);
+    assertEquals(urlGroup1.compareTo(urlGroup2), 0);
+  }
+
+  @Test
+  public void compareGroupToUnalikeGroupReturnsNonZero() {
+    UrlGroup urlGroup1 = new UrlGroup(GROUPID1);
+    UrlGroup urlGroup2 = new UrlGroup(GROUPID1);
+    UrlGroup urlGroup3 = new UrlGroup(GROUPID2);
+    assertTrue(urlGroup1.compareTo(urlGroup3) < 0); // "group1" < "group2"
+    PwPair pwPair3 = RankedDevice.createRankedPair(ID1, URL1, GROUPID1, RANK2);
+    urlGroup1.addPair(mPwPair1);
+    urlGroup2.addPair(pwPair3);
+    assertTrue(urlGroup1.compareTo(urlGroup2) < 0); // 0.5 < 0.9
+    assertTrue(urlGroup2.compareTo(urlGroup1) > 0);
   }
 }


### PR DESCRIPTION
Remove unnecessary null check on pwsResult in getUrlGroupsSortedByRank
Break ties when comparing UrlGroups by comparing groupid strings