### PR TITLE
Make http classes package private

### DIFF
--- a/java/libs/src/main/java/org/physical_web/collection/JsonObjectRequest.java
+++ b/java/libs/src/main/java/org/physical_web/collection/JsonObjectRequest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.physical_web.collection.http;
+package org.physical_web.collection;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -30,7 +30,7 @@ import java.net.MalformedURLException;
  * A class that represents an HTTP request for a JSON object.
  * Both the request payload and the response are JSON objects.
  */
-public class JsonObjectRequest extends Request<JSONObject> {
+class JsonObjectRequest extends Request<JSONObject> {
   private JSONObject mJsonObject;
 
   /**

--- a/java/libs/src/main/java/org/physical_web/collection/PwsClient.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PwsClient.java
@@ -15,9 +15,6 @@
  */
 package org.physical_web.collection;
 
-import org.physical_web.collection.http.JsonObjectRequest;
-import org.physical_web.collection.http.Request;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/java/libs/src/main/java/org/physical_web/collection/Request.java
+++ b/java/libs/src/main/java/org/physical_web/collection/Request.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.physical_web.collection.http;
+package org.physical_web.collection;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -27,7 +27,7 @@ import java.net.URL;
  * This is to be used as a base class for more specific request classes.
  * @param <T> The type representing the request payload.
  */
-public abstract class Request<T> extends Thread {
+abstract class Request<T> extends Thread {
   private URL mUrl;
   private RequestCallback<T> mCallback;
 

--- a/java/libs/src/main/java/org/physical_web/collection/Utils.java
+++ b/java/libs/src/main/java/org/physical_web/collection/Utils.java
@@ -18,7 +18,7 @@ package org.physical_web.collection;
 /**
  * Utility methods for the Physical Web library.
  */
-public class Utils {
+class Utils {
   /**
    * Compare two nullable comparables, preferring any non-null value over null.
    * @param o1 first object to compare


### PR DESCRIPTION
There are several classe that don't need to be exposed to developers.
This change makes them package private.