### PR TITLE
Move serialization to appropriate classes

### DIFF
--- a/java/libs/src/main/java/org/physical_web/collection/PwsResult.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PwsResult.java
@@ -15,10 +15,16 @@
  */
 package org.physical_web.collection;
 
+import org.json.JSONObject;
+
 /**
  * Metadata returned from the Physical Web Service for a single URL.
  */
 public class PwsResult implements Comparable<PwsResult> {
+  private static final String REQUESTURL_KEY = "requesturl";
+  private static final String SITEURL_KEY = "siteurl";
+  private static final String ICONURL_KEY = "iconurl";
+  private static final String GROUPID_KEY = "groupid";
   private String mRequestUrl;
   private String mSiteUrl;
   private String mIconUrl;
@@ -30,7 +36,7 @@ public class PwsResult implements Comparable<PwsResult> {
    * @param siteUrl The site URL, as reported by PWS
    * @param groupId The URL group ID, as reported by PWS
    */
-  PwsResult(String requestUrl, String siteUrl, String iconUrl, String groupId) {
+  public PwsResult(String requestUrl, String siteUrl, String iconUrl, String groupId) {
     mRequestUrl = requestUrl;
     mSiteUrl = siteUrl;
     mIconUrl = iconUrl;
@@ -90,6 +96,45 @@ public class PwsResult implements Comparable<PwsResult> {
    */
   public String getGroupId() {
     return mGroupId;
+  }
+
+  /**
+   * Create a JSON object that represents this data structure.
+   * @return a JSON serialization of this data structure.
+   */
+  public JSONObject jsonSerialize() {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put(REQUESTURL_KEY, mRequestUrl);
+    jsonObject.put(SITEURL_KEY, mSiteUrl);
+
+    if (mIconUrl != null) {
+      jsonObject.put(ICONURL_KEY, mIconUrl);
+    }
+
+    if (mGroupId != null) {
+      jsonObject.put(GROUPID_KEY, mGroupId);
+    }
+
+    return jsonObject;
+  }
+
+  /**
+   * Populate a PwsResult with data from a given JSON object.
+   * @param jsonObject a serialized PwsResult.
+   * @return The PwsResult represented by the serialized object.
+   */
+  public static PwsResult jsonDeserialize(JSONObject jsonObject) {
+    String requestUrl = jsonObject.getString(REQUESTURL_KEY);
+    String siteUrl = jsonObject.getString(SITEURL_KEY);
+    String iconUrl = null;
+    if (jsonObject.has(ICONURL_KEY)) {
+      iconUrl = jsonObject.getString(ICONURL_KEY);
+    }
+    String groupId = null;
+    if (jsonObject.has(GROUPID_KEY)) {
+      groupId = jsonObject.getString(GROUPID_KEY);
+    }
+    return new PwsResult(requestUrl, siteUrl, iconUrl, groupId);
   }
 
   /**

--- a/java/libs/src/main/java/org/physical_web/collection/UrlDevice.java
+++ b/java/libs/src/main/java/org/physical_web/collection/UrlDevice.java
@@ -15,19 +15,23 @@
  */
 package org.physical_web.collection;
 
+import org.json.JSONObject;
+
 /**
  * The class defining a Physical Web URL device.
  */
 public class UrlDevice {
-  protected String mId;
-  protected String mUrl;
+  private static final String ID_KEY = "id";
+  private static final String URL_KEY = "url";
+  private String mId;
+  private String mUrl;
 
   /**
    * Construct a SimpleUrlDevice.
    * @param id The id of the device.
    * @param url The URL broadcasted by the device.
    */
-  UrlDevice(String id, String url) {
+  public UrlDevice(String id, String url) {
     mId = id;
     mUrl = url;
   }
@@ -59,6 +63,29 @@ public class UrlDevice {
    */
   public double getRank(PwsResult pwsResult) {
     return .5;
+  }
+
+  /**
+   * Create a JSON object that represents this data structure.
+   * @return a JSON serialization of this data structure.
+   */
+  public JSONObject jsonSerialize() {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put(ID_KEY, mId);
+    jsonObject.put(URL_KEY, mUrl);
+    return jsonObject;
+  }
+
+  /**
+   * Populate a UrlDevice with data from a given JSON object.
+   * @param jsonObject a serialized UrlDevice.
+   * @return The UrlDevice represented by the serialized object.
+   */
+  public static UrlDevice jsonDeserialize(JSONObject jsonObject) {
+      //throws PhysicalWebCollectionException {
+    String id = jsonObject.getString(ID_KEY);
+    String url = jsonObject.getString(URL_KEY);
+    return new UrlDevice(id, url);
   }
 
   /**

--- a/java/libs/src/test/java/org/physical_web/collection/PhysicalWebCollectionTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/PhysicalWebCollectionTest.java
@@ -45,6 +45,7 @@ public class PhysicalWebCollectionTest {
   private static final String GROUP_ID1 = "group1";
   private static final String GROUP_ID2 = "group2";
   private PhysicalWebCollection physicalWebCollection1;
+  private JSONObject jsonObject1;
 
   private void addRankedDeviceAndMetadata(PhysicalWebCollection collection, String id, String url,
                                           String groupId, double rank) {
@@ -60,6 +61,19 @@ public class PhysicalWebCollectionTest {
     PwsResult pwsResult = new PwsResult(URL1, URL1, ICON_URL1, GROUP_ID1);
     physicalWebCollection1.addUrlDevice(urlDevice);
     physicalWebCollection1.addMetadata(pwsResult);
+    jsonObject1 = new JSONObject("{"
+        + "    \"schema\": 1,"
+        + "    \"devices\": [{"
+        + "        \"id\": \"" + ID1 + "\","
+        + "        \"url\": \"" + URL1 + "\""
+        + "    }],"
+        + "    \"metadata\": [{"
+        + "        \"requesturl\": \"" + URL1 + "\","
+        + "        \"siteurl\": \"" + URL1 + "\","
+        + "        \"iconurl\": \"" + ICON_URL1 + "\","
+        + "        \"groupid\": \"" + GROUP_ID1 + "\""
+        + "    }]"
+        + "}");
   }
 
   @Test
@@ -91,59 +105,22 @@ public class PhysicalWebCollectionTest {
 
   @Test
   public void jsonSerializeWorks() {
-    JSONObject jsonObject = new JSONObject("{"
-        + "    \"schema\": 1,"
-        + "    \"devices\": [{"
-        + "        \"id\": \"" + ID1 + "\","
-        + "        \"url\": \"" + URL1 + "\""
-        + "    }],"
-        + "    \"metadata\": [{"
-        + "        \"requesturl\": \"" + URL1 + "\","
-        + "        \"siteurl\": \"" + URL1 + "\","
-        + "        \"iconurl\": \"" + ICON_URL1 + "\","
-        + "        \"groupid\": \"" + GROUP_ID1 + "\""
-        + "    }]"
-        + "}");
-    JSONAssert.assertEquals(physicalWebCollection1.jsonSerialize(), jsonObject, true);
+    JSONAssert.assertEquals(physicalWebCollection1.jsonSerialize(), jsonObject1, true);
   }
 
   @Test
   public void jsonDeserializeWorks() throws PhysicalWebCollectionException {
-    PhysicalWebCollection physicalWebCollection = new PhysicalWebCollection();
-    JSONObject jsonObject = new JSONObject("{"
-        + "    \"schema\": 1,"
-        + "    \"devices\": [{"
-        + "        \"id\": \"" + ID1 + "\","
-        + "        \"url\": \"" + URL1 + "\""
-        + "    }],"
-        + "    \"metadata\": [{"
-        + "        \"requesturl\": \"" + URL1 + "\","
-        + "        \"siteurl\": \"" + URL1 + "\","
-        + "        \"iconurl\": \"" + ICON_URL1 + "\","
-        + "        \"groupid\": \"" + GROUP_ID1 + "\""
-        + "    }]"
-        + "}");
-    physicalWebCollection.jsonDeserialize(jsonObject);
+    PhysicalWebCollection physicalWebCollection =
+        PhysicalWebCollection.jsonDeserialize(jsonObject1);
     UrlDevice urlDevice = physicalWebCollection.getUrlDeviceById(ID1);
     PwsResult pwsResult = physicalWebCollection.getMetadataByBroadcastUrl(URL1);
     assertNotNull(urlDevice);
     assertEquals(urlDevice.getId(), ID1);
     assertEquals(urlDevice.getUrl(), URL1);
+    assertNotNull(pwsResult);
     assertEquals(pwsResult.getRequestUrl(), URL1);
     assertEquals(pwsResult.getSiteUrl(), URL1);
     assertEquals(pwsResult.getGroupId(), GROUP_ID1);
-  }
-
-  @Test
-  public void jsonSerializeAndDeserializePreservesNullValues() throws Exception {
-    PhysicalWebCollection physicalWebCollection = new PhysicalWebCollection();
-    physicalWebCollection.addMetadata(new PwsResult(URL1, URL1, null, null));  // null values
-
-    PhysicalWebCollection deserializedCollection = new PhysicalWebCollection();
-    deserializedCollection.jsonDeserialize(physicalWebCollection.jsonSerialize());
-    PwsResult deserializedResult = deserializedCollection.getMetadataByBroadcastUrl(URL1);
-    assertNull(deserializedResult.getIconUrl());
-    assertNull(deserializedResult.getGroupId());
   }
 
   @Test

--- a/java/libs/src/test/java/org/physical_web/collection/PwsResultTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/PwsResultTest.java
@@ -17,8 +17,12 @@ package org.physical_web.collection;
 
 import static org.junit.Assert.*;
 
+import org.json.JSONObject;
+
 import org.junit.Before;
 import org.junit.Test;
+
+import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * PwsResult unit test class.
@@ -31,10 +35,17 @@ public class PwsResultTest {
   private static final String GROUP_ID1 = "group1";
   private static final String GROUP_ID2 = "group2";
   private PwsResult mPwsResult1 = null;
+  private JSONObject jsonObject1 = null;
 
   @Before
   public void setUp() {
     mPwsResult1 = new PwsResult(URL1, URL1, ICON_URL1, GROUP_ID1);
+    jsonObject1 = new JSONObject("{"
+        + "    \"requesturl\": \"" + URL1 + "\","
+        + "    \"siteurl\": \"" + URL1 + "\","
+        + "    \"iconurl\": \"" + ICON_URL1 + "\","
+        + "    \"groupid\": \"" + GROUP_ID1 + "\""
+        + "}");
   }
 
   @Test
@@ -43,6 +54,28 @@ public class PwsResultTest {
     assertEquals(mPwsResult1.getSiteUrl(), URL1);
     assertEquals(mPwsResult1.getIconUrl(), ICON_URL1);
     assertEquals(mPwsResult1.getGroupId(), GROUP_ID1);
+  }
+
+  @Test
+  public void jsonSerializeWorks() {
+    JSONAssert.assertEquals(mPwsResult1.jsonSerialize(), jsonObject1, true);
+  }
+
+  @Test
+  public void jsonDeserializeWorks() throws PhysicalWebCollectionException {
+    PwsResult pwsResult = PwsResult.jsonDeserialize(jsonObject1);
+    assertNotNull(pwsResult);
+    assertEquals(pwsResult.getRequestUrl(), URL1);
+    assertEquals(pwsResult.getSiteUrl(), URL1);
+    assertEquals(pwsResult.getGroupId(), GROUP_ID1);
+  }
+
+  @Test
+  public void jsonSerializeAndDeserializePreservesNullValues() throws Exception {
+    PwsResult pwsResult = new PwsResult(URL1, URL1, null, null);  // null values
+    pwsResult = PwsResult.jsonDeserialize(pwsResult.jsonSerialize());
+    assertNull(pwsResult.getIconUrl());
+    assertNull(pwsResult.getGroupId());
   }
 
   @Test

--- a/java/libs/src/test/java/org/physical_web/collection/UrlDeviceTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/UrlDeviceTest.java
@@ -17,8 +17,12 @@ package org.physical_web.collection;
 
 import static org.junit.Assert.*;
 
+import org.json.JSONObject;
+
 import org.junit.Before;
 import org.junit.Test;
+
+import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * SimpleUrlDevice unit test class.
@@ -31,10 +35,15 @@ public class UrlDeviceTest {
   private static final double RANK1 = 0.5d;
   private static final double RANK2 = 0.9d;
   private UrlDevice mUrlDevice1;
+  private JSONObject jsonObject1;
 
   @Before
   public void setUp() {
     mUrlDevice1 = new UrlDevice(ID1, URL1);
+    jsonObject1 = new JSONObject("{"
+        + "    \"id\": \"" + ID1 + "\","
+        + "    \"url\": \"" + URL1 + "\""
+        + "}");
   }
 
   @Test
@@ -51,6 +60,19 @@ public class UrlDeviceTest {
   public void getRankReturnsPointFive() {
     PwsResult pwsResult = new PwsResult(URL1, URL1, null, null);
     assertEquals(.5, mUrlDevice1.getRank(pwsResult), .0001);
+  }
+
+  @Test
+  public void jsonSerializeWorks() {
+    JSONAssert.assertEquals(mUrlDevice1.jsonSerialize(), jsonObject1, true);
+  }
+
+  @Test
+  public void jsonDeserializeWorks() {
+    UrlDevice urlDevice = UrlDevice.jsonDeserialize(jsonObject1);
+    assertNotNull(urlDevice);
+    assertEquals(urlDevice.getId(), ID1);
+    assertEquals(urlDevice.getUrl(), URL1);
   }
 
   @Test


### PR DESCRIPTION
Instead of having all serialization exist in PhysicalWebCollection,
this change moves appropriate serialization to PwsResult and UrlDevice.