### PR TITLE
Add extra data to PwsResult and UrlDevice

### DIFF
--- a/java/libs/src/main/java/org/physical_web/collection/PwsResult.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PwsResult.java
@@ -25,10 +25,12 @@ public class PwsResult implements Comparable<PwsResult> {
   private static final String SITEURL_KEY = "siteurl";
   private static final String ICONURL_KEY = "iconurl";
   private static final String GROUPID_KEY = "groupid";
+  private static final String EXTRA_KEY = "extra";
   private String mRequestUrl;
   private String mSiteUrl;
   private String mIconUrl;
   private String mGroupId;
+  private JSONObject mExtraData;
 
   /**
    * Construct a PwsResult.
@@ -41,6 +43,7 @@ public class PwsResult implements Comparable<PwsResult> {
     mSiteUrl = siteUrl;
     mIconUrl = iconUrl;
     mGroupId = groupId;
+    mExtraData = new JSONObject();
   }
 
   /**
@@ -99,6 +102,15 @@ public class PwsResult implements Comparable<PwsResult> {
   }
 
   /**
+   * Get extra data JSONObject.
+   * This is where client code should store custom data.
+   * @return Extra data.
+   */
+  public JSONObject getExtraData() {
+    return mExtraData;
+  }
+
+  /**
    * Create a JSON object that represents this data structure.
    * @return a JSON serialization of this data structure.
    */
@@ -113,6 +125,10 @@ public class PwsResult implements Comparable<PwsResult> {
 
     if (mGroupId != null) {
       jsonObject.put(GROUPID_KEY, mGroupId);
+    }
+
+    if (mExtraData.length() > 0) {
+      jsonObject.put(EXTRA_KEY, mExtraData);
     }
 
     return jsonObject;
@@ -134,11 +150,17 @@ public class PwsResult implements Comparable<PwsResult> {
     if (jsonObject.has(GROUPID_KEY)) {
       groupId = jsonObject.getString(GROUPID_KEY);
     }
-    return new PwsResult(requestUrl, siteUrl, iconUrl, groupId);
+
+    PwsResult pwsResult = new PwsResult(requestUrl, siteUrl, iconUrl, groupId);
+    if (jsonObject.has(EXTRA_KEY)) {
+      pwsResult.mExtraData = jsonObject.getJSONObject(EXTRA_KEY);
+    }
+    return pwsResult;
   }
 
   /**
    * Return a hash code for this PwsResult.
+   * This calculation does not include the extra data.
    * @return hash code
    */
   @Override
@@ -153,6 +175,7 @@ public class PwsResult implements Comparable<PwsResult> {
 
   /**
    * Check if two PwsResults are equal.
+   * This does not compare extra data.
    * @param other the PwsResult to compare to.
    * @return true if the PwsResults are equal.
    */
@@ -163,7 +186,8 @@ public class PwsResult implements Comparable<PwsResult> {
     }
 
     if (other instanceof PwsResult) {
-      return compareTo((PwsResult) other) == 0;
+      PwsResult pwsResult = (PwsResult) other;
+      return compareTo(pwsResult) == 0;
     }
     return false;
   }

--- a/java/libs/src/main/java/org/physical_web/collection/UrlDevice.java
+++ b/java/libs/src/main/java/org/physical_web/collection/UrlDevice.java
@@ -23,8 +23,10 @@ import org.json.JSONObject;
 public class UrlDevice {
   private static final String ID_KEY = "id";
   private static final String URL_KEY = "url";
+  private static final String EXTRA_KEY = "extra";
   private String mId;
   private String mUrl;
+  private JSONObject mExtraData;
 
   /**
    * Construct a SimpleUrlDevice.
@@ -34,6 +36,7 @@ public class UrlDevice {
   public UrlDevice(String id, String url) {
     mId = id;
     mUrl = url;
+    mExtraData = new JSONObject();
   }
 
   /**
@@ -66,6 +69,15 @@ public class UrlDevice {
   }
 
   /**
+   * Get extra data JSONObject.
+   * This is where client code should store custom data.
+   * @return Extra data.
+   */
+  public JSONObject getExtraData() {
+    return mExtraData;
+  }
+
+  /**
    * Create a JSON object that represents this data structure.
    * @return a JSON serialization of this data structure.
    */
@@ -73,6 +85,11 @@ public class UrlDevice {
     JSONObject jsonObject = new JSONObject();
     jsonObject.put(ID_KEY, mId);
     jsonObject.put(URL_KEY, mUrl);
+
+    if (mExtraData.length() > 0) {
+      jsonObject.put(EXTRA_KEY, mExtraData);
+    }
+
     return jsonObject;
   }
 
@@ -82,14 +99,19 @@ public class UrlDevice {
    * @return The UrlDevice represented by the serialized object.
    */
   public static UrlDevice jsonDeserialize(JSONObject jsonObject) {
-      //throws PhysicalWebCollectionException {
     String id = jsonObject.getString(ID_KEY);
     String url = jsonObject.getString(URL_KEY);
-    return new UrlDevice(id, url);
+
+    UrlDevice urlDevice = new UrlDevice(id, url);
+    if (jsonObject.has(EXTRA_KEY)) {
+      urlDevice.mExtraData = jsonObject.getJSONObject(EXTRA_KEY);
+    }
+    return urlDevice;
   }
 
   /**
    * Return a hash code for this SimpleUrlDevice.
+   * This calculation does not include the extra data.
    * @return hash code
    */
   public int hashCode() {
@@ -101,6 +123,7 @@ public class UrlDevice {
 
   /**
    * Check if two UrlDevices are equal.
+   * This does not compare extra data.
    * @param other the UrlDevice to compare to.
    * @return true if the UrlDevices are equal
    */
@@ -110,9 +133,8 @@ public class UrlDevice {
     }
 
     if (other instanceof UrlDevice) {
-      UrlDevice otherUrlDevice = (UrlDevice) other;
-      return mId.equals(otherUrlDevice.getId()) &&
-          mUrl.equals(otherUrlDevice.getUrl());
+      UrlDevice urlDevice = (UrlDevice) other;
+      return compareTo(urlDevice) == 0;
     }
     return false;
   }

--- a/java/libs/src/test/java/org/physical_web/collection/PwsResultTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/PwsResultTest.java
@@ -40,11 +40,16 @@ public class PwsResultTest {
   @Before
   public void setUp() {
     mPwsResult1 = new PwsResult(URL1, URL1, ICON_URL1, GROUP_ID1);
+    mPwsResult1.getExtraData().put("key", "value");
+    String endline = "\",";
     jsonObject1 = new JSONObject("{"
-        + "    \"requesturl\": \"" + URL1 + "\","
-        + "    \"siteurl\": \"" + URL1 + "\","
-        + "    \"iconurl\": \"" + ICON_URL1 + "\","
-        + "    \"groupid\": \"" + GROUP_ID1 + "\""
+        + "    \"requesturl\": \"" + URL1 + endline
+        + "    \"siteurl\": \"" + URL1 + endline
+        + "    \"iconurl\": \"" + ICON_URL1 + endline
+        + "    \"groupid\": \"" + GROUP_ID1 + endline
+        + "    \"extra\": {"
+        + "        \"key\": \"value\""
+        + "    }"
         + "}");
   }
 
@@ -54,6 +59,11 @@ public class PwsResultTest {
     assertEquals(mPwsResult1.getSiteUrl(), URL1);
     assertEquals(mPwsResult1.getIconUrl(), ICON_URL1);
     assertEquals(mPwsResult1.getGroupId(), GROUP_ID1);
+  }
+
+  @Test
+  public void getExtraDataWorks() {
+    assertEquals(1, mPwsResult1.getExtraData().length());
   }
 
   @Test
@@ -85,7 +95,9 @@ public class PwsResultTest {
 
   @Test
   public void alikeResultsAreEqual() {
-    assertEquals(mPwsResult1, new PwsResult(URL1, URL1, ICON_URL1, GROUP_ID1));
+    PwsResult pwsResult = new PwsResult(URL1, URL1, ICON_URL1, GROUP_ID1);
+    pwsResult.getExtraData().put("key", "value");
+    assertEquals(mPwsResult1, pwsResult);
   }
 
   @Test

--- a/java/libs/src/test/java/org/physical_web/collection/UrlDeviceTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/UrlDeviceTest.java
@@ -40,9 +40,13 @@ public class UrlDeviceTest {
   @Before
   public void setUp() {
     mUrlDevice1 = new UrlDevice(ID1, URL1);
+    mUrlDevice1.getExtraData().put("key", "value");
     jsonObject1 = new JSONObject("{"
         + "    \"id\": \"" + ID1 + "\","
-        + "    \"url\": \"" + URL1 + "\""
+        + "    \"url\": \"" + URL1 + "\","
+        + "    \"extra\": {"
+        + "        \"key\": \"value\""
+        + "    }"
         + "}");
   }
 
@@ -60,6 +64,11 @@ public class UrlDeviceTest {
   public void getRankReturnsPointFive() {
     PwsResult pwsResult = new PwsResult(URL1, URL1, null, null);
     assertEquals(.5, mUrlDevice1.getRank(pwsResult), .0001);
+  }
+
+  @Test
+  public void getExtraDataWorks() {
+    assertEquals(1, mUrlDevice1.getExtraData().length());
   }
 
   @Test
@@ -82,8 +91,9 @@ public class UrlDeviceTest {
 
   @Test
   public void alikeDevicesAreEqual() {
-    UrlDevice urlDevice2 = new UrlDevice(ID1, URL1);
-    assertEquals(mUrlDevice1, urlDevice2);
+    UrlDevice urlDevice = new UrlDevice(ID1, URL1);
+    urlDevice.getExtraData().put("key", "value");
+    assertEquals(mUrlDevice1, urlDevice);
   }
 
   @Test
@@ -96,8 +106,9 @@ public class UrlDeviceTest {
 
   @Test
   public void devicesWithDifferentRankButSameInfoAreEqual() {
-    UrlDevice urlDevice2 = new RankedDevice(ID1, URL1, RANK2); // different rank
-    assertEquals(mUrlDevice1, urlDevice2); // equals should not consider rank
+    UrlDevice urlDevice = new RankedDevice(ID1, URL1, RANK2); // different rank
+    urlDevice.getExtraData().put("key", "value");
+    assertEquals(mUrlDevice1, urlDevice); // equals should not consider rank
   }
 
   @Test


### PR DESCRIPTION
Add putters and getters for PwsResult and UrlDevice so that clients
can store arbitrary data associated with each.  This is better than
our previous solution of requiring client code to subclass these.