### PR TITLE
Share data directly between Fragment and Service

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/BeaconDisplayList.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/BeaconDisplayList.java
@@ -184,6 +184,20 @@ class BeaconDisplayList {
   }
 
   /**
+   * Return true if any contained pwo has the specified URL.
+   * @param url The URL
+   * @return boolean true if present
+   */
+  public boolean containsUrl(String url) {
+    for (BeaconDisplayItem beaconDisplayItem : mDisplayList) {
+      if (beaconDisplayItem.top().url.equals(url)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Return the display list item count.
    * @return Count of displayed items
    */


### PR DESCRIPTION
Instead of subscribing to every detailed update, the fragment now
shares data directly with the service and receives notices when
any data has changed.  This simplifies the interactions between the
two, paving the way for a shared Collection (when we integrate the
collections library).

One aspect of this change is that it replaces the fragments
mPwoMetadataQueue with an mUrlQueue.  This is simplier for checking
whether new urls are already stored in the queue, but it also will
allow us to access the most appropriate metadata at the time of
display, as opposed to at the time of placing the data into the
queue.