### PR TITLE
Allow request subclasses to setDoOutput

### DIFF
--- a/java/libs/src/main/java/org/physical_web/collection/JsonObjectRequest.java
+++ b/java/libs/src/main/java/org/physical_web/collection/JsonObjectRequest.java
@@ -56,6 +56,7 @@ class JsonObjectRequest extends Request<JSONObject> {
    * @param urlConnection The HTTP connection.
    */
   public void writeToUrlConnection(HttpURLConnection urlConnection) throws IOException {
+    urlConnection.setDoOutput(true);
     urlConnection.setRequestProperty("Content-Type", "application/json");
     urlConnection.setRequestProperty("Accept", "application/json");
     urlConnection.setRequestMethod("POST");

--- a/java/libs/src/main/java/org/physical_web/collection/Request.java
+++ b/java/libs/src/main/java/org/physical_web/collection/Request.java
@@ -76,7 +76,6 @@ abstract class Request<T> extends Thread {
     // Make the request
     try {
       urlConnection = (HttpURLConnection) mUrl.openConnection();
-      urlConnection.setDoOutput(true);
       writeToUrlConnection(urlConnection);
       responseCode = urlConnection.getResponseCode();
       inputStream = new BufferedInputStream(urlConnection.getInputStream());


### PR DESCRIPTION
This will prevent us from making POST requests with the BitmapRequest
class.