### PR TITLE
Add missing punctuation

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
 <h3>How does it work?</h3>
 <p>A small utility on the phone scans for URLs that are nearby. We are  using the open <a href="https://github.com/google/eddystone">Eddystone-URL</a> Bluetooth beacon format to find nearby URLs without requiring any centralized registrar. Here is a <a href="https://developers.google.com/beacons/">list of many beacon makers</a> that are already supporting Eddystone. We also support finding URLs through Wifi using mDNS and uPnP.</p>
 
-<p>To learn more, visit the <a href="http://www.github.com/google/physical-web">project on GitHub</a></p>
+<p>To learn more, visit the <a href="http://www.github.com/google/physical-web">project on GitHub</a>.</p>
 </section>
 
       </div>


### PR DESCRIPTION
There was a period missing in the last sentence, so I added it.