### PR TITLE
Responsive embeds and heading line height

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -35,3 +35,4 @@ louaybassbouss
 devunwired
 ColeMurray
 edent
+jaicab

--- a/cookbook/index.html
+++ b/cookbook/index.html
@@ -70,7 +70,9 @@
 <h3>Moving Beacon</h3>
 <p>Beacons don't have to be stationary either. A dog collar could link to a page for of basic information. However, if the dog is lost, the owner can call into the the service and update the page.
 </p>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/-Y77cUI_z30" frameborder="0" allowfullscreen></iframe>
+<div class="embed-container">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/-Y77cUI_z30" frameborder="0" allowfullscreen></iframe>
+</div>
 
 <h2>Let's Dive Deeper</h2>
 <p>We can build even more compelling experiences when we introduce a link between the Physical Web object and the webpage loaded on the user's device.</p>
@@ -81,26 +83,37 @@
 <h3>Push Notifications</h3>
 <p>The beacon broadcasts the URL of a webpage that implements a Service Worker with push notifications. For example, a restaurant can create a queueing system that doesn't require the user to ask the hostess for a piece of plastic with a buzzer and LEDs in it. Instead, the user easily opens up the queuing web app, grabs a spot in a digital line, and gets notified when the time is right.
 </p>
-
 <p>Here is a demo of how this could work:</p>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/b0GDk-53fTo" frameborder="0" allowfullscreen></iframe>
+
+<div class="embed-container">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/b0GDk-53fTo" frameborder="0" allowfullscreen></iframe>
+</div>
 
 <h3>Parking Meter</h3>
 <p>The parking meter has a radio antennae providing internet access. The beacon within points to a webpage (with the meter's ID encoded in the URL) that uses websockets to connect to the parking meter. From this webpage, the user can easily use credit card autofill or other online payment APIs to add time to the meter.</p>
 
 <p>Here is a demo of how this could work:</p>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/ysxB_PXFImE" frameborder="0" allowfullscreen></iframe>
+
+<div class="embed-container">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/ysxB_PXFImE" frameborder="0" allowfullscreen></iframe>
+</div>
 <br/><br/>
 
 <h3>Voting Wall</h3>
 <p>The Physical Web doesn't need to be a 1:1 ratio of 1 device to 1 person. Everyone in a room could access the same link to a voting wall. People could vote up and down questions as they are asked. Here is a demo of how that could work:
 </p>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/0SDJrRk3YC8" frameborder="0" allowfullscreen></iframe>
+
+<div class="embed-container">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/0SDJrRk3YC8" frameborder="0" allowfullscreen></iframe>
+</div>
 
 <h3>Photo Wall</h3>
 <p>In this case, a large display acts as a photo wall, you just need to take out your phone, choose the photo wall and either browse the existing photos or add one yourself to the wall. 
 </p>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/-e7yWs38UIQ" frameborder="0" allowfullscreen></iframe>
+
+<div class="embed-container">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/-e7yWs38UIQ" frameborder="0" allowfullscreen></iframe>
+</div>
 
 <h2>New possibilities with Web Bluetooth</h2>
 <p>A standardized open web JavaScript Bluetooth API is currently in the works. This API will allow webpages to directly connect to nearby Bluetooth devices.</p>
@@ -109,12 +122,16 @@
 
 <h3>Happy Meal Toy</h3>
 <p>In this example, the toy broadcasts a URL to a webpage that contains JavaScript to directly connect to the toy via Bluetooth.The toy is a standalone device that can be played with by youngsters, while the webpage interaction lets the parent easily configure and personalize the toy.</p>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/PwK3ccOJ6EY" frameborder="0" allowfullscreen></iframe>
+<div class="embed-container">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/PwK3ccOJ6EY" frameborder="0" allowfullscreen></iframe>
+</div>
 
 <h3>Remote Control</h3>
 <p>This uses the same technique as the Happy Meal Toy but in this case, we are controlling an existing toy you can buy off the shelf. The company has documented their control API and it's easy to connect and control the toy from a web page using the Web Bluetooth Javascript API:
 </p>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/6z9ED4fmi1w" frameborder="0" allowfullscreen></iframe>
+<div class="embed-container">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/6z9ED4fmi1w" frameborder="0" allowfullscreen></iframe>
+</div>
 <p>To learn more, visit the <a href="http://www.github.com/google/physical-web">project on GitHub</a></p>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -46,7 +46,9 @@
         <section id="main-content">
 <h3>What is this?</h3>
 <p>The Physical Web is an open source approach to unleash the core superpower of the web: interaction on demand. People should be able to walk up to any smart device - a vending machine, a poster, a toy, a bus stop, a rental car - and not have to download an app first. Everything should be just a tap away.</p>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/1yaLPRgtlR0" frameborder="0" allowfullscreen></iframe>
+<div class="embed-container">
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/1yaLPRgtlR0" frameborder="0" allowfullscreen></iframe>
+</div>
 
 <p>We're developing it out in the open as we do all things related to the web. While Google is creating <a href="http://blog.chromium.org/2016/02/the-physical-web-expands-to-chrome-for_10.html">an initial implementation</a>, we hope others join in as well.</p>
 

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -381,9 +381,7 @@ footer a:hover {
   margin-bottom: 1em;
 } 
 
-.embed-container iframe, 
-.embed-container object, 
-.embed-container embed { 
+.embed-container iframe { 
   position: absolute; 
   top: 0; left: 0; 
   width: 100%; 

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -229,6 +229,8 @@ form {
   font-size: 2.8em;
   letter-spacing: -1px;
   color: #474747;
+  line-height: 1;
+  margin-bottom: .25em;
 }
 
 #main-content h1:before {

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -369,6 +369,25 @@ footer a:hover {
 * html .clearfix {height: 1%;}
 .clearfix {display: block;}
 
+
+.embed-container { 
+  position: relative; 
+  padding-bottom: 56.25%; 
+  height: 0; 
+  overflow: hidden; 
+  max-width: 100%; 
+  margin-bottom: 1em;
+} 
+
+.embed-container iframe, 
+.embed-container object, 
+.embed-container embed { 
+  position: absolute; 
+  top: 0; left: 0; 
+  width: 100%; 
+  height: 100%; 
+}
+
 /* #Media Queries
 ================================================== */
 


### PR DESCRIPTION
The YouTube embeds on the website weren't responsive, causing a increase in layout width on mobile, breaking the experience. Using the common pattern of 16:9 aspect ratio for responsive embeds via CSS I applied it to all the iframes in the HTML.

I also fixed a line height problem in the headings as it was being relied on for margin. In cases where the headings go to two lines, the spacing was huge. So changed it to 1 and applied margin bottom.