### PR TITLE
Group ID Formation Fix

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -35,3 +35,4 @@ louaybassbouss
 devunwired
 ColeMurray
 edent
+kevinahuber

--- a/web-service/helpers.py
+++ b/web-service/helpers.py
@@ -152,7 +152,13 @@ def ReplaceDistanceWithRank(device_data):
 def ComputeGroupId(url, title, description):
     import hashlib
     domain = urlparse(url).netloc
-    seed = domain + '\0' + title
+    if title is not None:
+        identifier = title
+    elif description is not None:
+        identifier = description
+    else:
+        identifier = urlparse(url).path
+    seed = domain + '\0' + identifier
     groupid = hashlib.sha1(seed.encode('utf-8')).hexdigest()[:16]
     return groupid
 


### PR DESCRIPTION
Fixes the issue caused by the first URL in #654: https://www.cvs.com/deals/deals.jsp

When a group id is formed, it fails if the title is None. Rather than just using the domain when the title is None, I am proposing that we fall back to the description, then to the path. This would ensure that the group ID would fall back to be more unique, rather than less.