### PR TITLE
Add HTTPS only to Android only

### DIFF
--- a/implementation-status.md
+++ b/implementation-status.md
@@ -8,7 +8,8 @@ Feature                   | iOS       | Android
 ------------------------- | :-------: | :-------: 
 Eddystone-URL scanning    | ✓         | ✓          
 Notifications             |           | ✓          
-Favicon support           |           | ✓          
+Favicon support           |           | ✓     
+HTTPS only                |           | ✓
 
 ### Notes
 


### PR DESCRIPTION
Hopefully we'll mark HTTPS only for iOS soon but for now we should be honest about it with developers and communicate this clearly.