### PR TITLE
Fix location permission crash

### DIFF
--- a/android/PhysicalWeb/app/build.gradle
+++ b/android/PhysicalWeb/app/build.gradle
@@ -4,13 +4,13 @@ apply plugin: 'findbugs'
 apply plugin: 'pmd'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "physical_web.org.physicalweb"
         minSdkVersion 19
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 15
         versionName "0.1.856"
     }
@@ -68,7 +68,7 @@ dependencies {
 
     compile 'com.android.volley:volley@aar'
     compile 'org.uribeacon:uribeacon-library-release@aar'
-    compile 'com.android.support:appcompat-v7:22.1.1'
+    compile 'com.android.support:appcompat-v7:23.0.1'
 }
 
 task checkstyle(type: Checkstyle) {

--- a/android/PhysicalWeb/app/src/main/AndroidManifest.xml
+++ b/android/PhysicalWeb/app/src/main/AndroidManifest.xml
@@ -77,6 +77,7 @@
         <service
             android:name=".PhysicalWebBroadcastService"
             android:enabled="true"
+            android:stopWithTask="false"
             android:exported="false">
         </service>
 

--- a/android/PhysicalWeb/app/src/main/res/values/strings.xml
+++ b/android/PhysicalWeb/app/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="url_broadcast">URL is broadcasting!</string>
     <string name="broadcast_notif">Physical Web is broadcasting a URL</string>
     <string name="shorten_error">Could not shorten URL</string>
+    <string name="loc_permission">Needs Location permission</string>
     <string name="stop">Stop</string>
     <plurals name="numFoundBeacons">
         <item quantity="one">Beacon Nearby</item>


### PR DESCRIPTION
The broadcast service is killed by the OS when Bluetooth
Permissions are revoked. Therefore, it must handled and
restarted properly