### PR TITLE
Check for neccesary permission in API 23 or above

### DIFF
--- a/android/PhysicalWeb/app/build.gradle
+++ b/android/PhysicalWeb/app/build.gradle
@@ -4,13 +4,13 @@ apply plugin: 'findbugs'
 apply plugin: 'pmd'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "physical_web.org.physicalweb"
         minSdkVersion 19
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 15
         versionName "0.1.856"
     }
@@ -68,7 +68,7 @@ dependencies {
 
     compile 'com.android.volley:volley@aar'
     compile 'org.uribeacon:uribeacon-library-release@aar'
-    compile 'com.android.support:appcompat-v7:22.1.1'
+    compile 'com.android.support:appcompat-v7:23.0.1'
 }
 
 task checkstyle(type: Checkstyle) {

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
@@ -208,6 +208,7 @@ public class NearbyBeaconsFragment extends ListFragment
     listView.setOnItemLongClickListener(mAdapterViewItemLongClickListener);
   }
 
+  @Override
   public View onCreateView(LayoutInflater layoutInflater, ViewGroup container,
                            Bundle savedInstanceState) {
     View rootView = layoutInflater.inflate(R.layout.fragment_nearby_beacons, container, false);

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PhysicalWebBroadcastService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/PhysicalWebBroadcastService.java
@@ -38,11 +38,12 @@ import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.app.TaskStackBuilder;
 import android.util.Log;
 import android.widget.Toast;
-import org.physical_web.physicalweb.ble.AdvertiseDataUtils;
-import org.physical_web.physicalweb.ble.UriBeacon;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+
+import org.physical_web.physicalweb.ble.AdvertiseDataUtils;
+import org.physical_web.physicalweb.ble.UriBeacon;
 /**
   * Shares URLs via bluetooth.
   * Also interfaces with PWS to shorten URLs that are too long for Eddystone URLs.

--- a/android/PhysicalWeb/app/src/main/res/values/strings.xml
+++ b/android/PhysicalWeb/app/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="url_broadcast">URL is broadcasting!</string>
     <string name="broadcast_notif">Physical Web is broadcasting a URL</string>
     <string name="shorten_error">Could not shorten URL</string>
+    <string name="loc_permission">Needs Location permission</string>
     <string name="stop">Stop</string>
     <plurals name="numFoundBeacons">
         <item quantity="one">Beacon Nearby</item>


### PR DESCRIPTION
Given that runtime permission can be changed, we must
check that the proper permissions are enabled to ensure
that scanning will work properly.