### PR TITLE
Preventing Repeated Resolves

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UrlDeviceDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UrlDeviceDiscoveryService.java
@@ -257,47 +257,50 @@ public class UrlDeviceDiscoveryService extends Service
 
   @Override
   public void onUrlDeviceDiscovered(UrlDevice urlDevice) {
-    mPwCollection.addUrlDevice(urlDevice);
-    mPwCollection.fetchPwsResults(new PwsResultCallback() {
-      long mPwsTripTimeMillis = 0;
+    boolean alreadyFound = mPwCollection.addUrlDevice(urlDevice);
+    if (!alreadyFound){
+      mPwCollection.fetchPwsResults(new PwsResultCallback() {
+        long mPwsTripTimeMillis = 0;
 
-      @Override
-      public void onPwsResult(PwsResult pwsResult) {
-        PwsResult replacement = new Utils.PwsResultBuilder(pwsResult)
-            .setPwsTripTimeMillis(pwsResult, mPwsTripTimeMillis)
-            .build();
-        mPwCollection.addMetadata(replacement);
-        triggerCallback();
-        updateNotifications();
-      }
+        @Override
+        public void onPwsResult(PwsResult pwsResult) {
+          PwsResult replacement = new Utils.PwsResultBuilder(pwsResult)
+              .setPwsTripTimeMillis(pwsResult, mPwsTripTimeMillis)
+              .build();
+          mPwCollection.addMetadata(replacement);
+          triggerCallback();
+          updateNotifications();
+        }
 
-      @Override
-      public void onPwsResultAbsent(String url) {
-        triggerCallback();
-      }
+        @Override
+        public void onPwsResultAbsent(String url) {
+          triggerCallback();
+        }
 
-      @Override
-      public void onPwsResultError(Collection<String> urls, int httpResponseCode, Exception e) {
-        Log.d(TAG, "PwsResultError: " + httpResponseCode + " ", e);
-        triggerCallback();
-      }
+        @Override
+        public void onPwsResultError(Collection<String> urls, int httpResponseCode, Exception e) {
+          Log.d(TAG, "PwsResultError: " + httpResponseCode + " ", e);
+          triggerCallback();
+        }
 
-      @Override
-      public void onResponseReceived(long durationMillis) {
-        mPwsTripTimeMillis = durationMillis;
-      }
-    }, new PwsResultIconCallback() {
-      @Override
-      public void onIcon(byte[] icon) {
-        triggerCallback();
-      }
+        @Override
+        public void onResponseReceived(long durationMillis) {
+          mPwsTripTimeMillis = durationMillis;
+        }
+      }, new PwsResultIconCallback() {
+        @Override
+        public void onIcon(byte[] icon) {
+          triggerCallback();
+        }
 
-      @Override
-      public void onError(int httpResponseCode, Exception e) {
-        Log.d(TAG, "PwsResultError: " + httpResponseCode + " ", e);
-        triggerCallback();
-      }
-    });
+        @Override
+        public void onError(int httpResponseCode, Exception e) {
+          Log.d(TAG, "PwsResultError: " + httpResponseCode + " ", e);
+          triggerCallback();
+        }
+      });
+      triggerCallback();      
+    }
     triggerCallback();
   }
 

--- a/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
@@ -41,6 +41,7 @@ public class PhysicalWebCollection {
   private Map<String, byte[]> mIconUrlToIconMap;
   private Set<String> mPendingBroadcastUrls;
   private Set<String> mPendingIconUrls;
+  private Set<String> mFailedResolveUrls;
 
   /**
    * Construct a PhysicalWebCollection.
@@ -52,14 +53,17 @@ public class PhysicalWebCollection {
     mIconUrlToIconMap = new HashMap<>();
     mPendingBroadcastUrls = new HashSet<>();
     mPendingIconUrls = new HashSet<>();
+    mFailedResolveUrls = new HashSet<>();
   }
 
   /**
    * Add a UrlDevice to the collection.
    * @param urlDevice The UrlDevice to add.
    */
-  public void addUrlDevice(UrlDevice urlDevice) {
+  public boolean addUrlDevice(UrlDevice urlDevice) {
+    boolean alreadyFound = mDeviceIdToUrlDeviceMap.containsKey(urlDevice.getId());
     mDeviceIdToUrlDeviceMap.put(urlDevice.getId(), urlDevice);
+    return alreadyFound;
   }
 
   /**
@@ -348,7 +352,7 @@ public class PhysicalWebCollection {
     Set<String> newIconUrls = new HashSet<>();
     for (UrlDevice urlDevice : mDeviceIdToUrlDeviceMap.values()) {
       String url = urlDevice.getUrl();
-      if (!mPendingBroadcastUrls.contains(url)) {
+      if (!mPendingBroadcastUrls.contains(url) && !mFailedResolveUrls.contains(url)) {
         PwsResult pwsResult = mBroadcastUrlToPwsResultMap.get(url);
         if (pwsResult == null) {
           newResolveUrls.add(url);
@@ -378,6 +382,7 @@ public class PhysicalWebCollection {
 
       @Override
       public void onPwsResultAbsent(String url) {
+        mFailedResolveUrls.add(url);
         pwsResultCallback.onPwsResultAbsent(url);
       }
 


### PR DESCRIPTION
When a URL is not resolved by the PWS, the client
will continue to attempt to fetch a result unnecessarily