### PR TITLE
Preventing Repeated Fetches and Resolves

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UrlDeviceDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UrlDeviceDiscoveryService.java
@@ -257,7 +257,11 @@ public class UrlDeviceDiscoveryService extends Service
 
   @Override
   public void onUrlDeviceDiscovered(UrlDevice urlDevice) {
-    mPwCollection.addUrlDevice(urlDevice);
+    // check if device has already been discovered
+    if (mPwCollection.addUrlDevice(urlDevice)) {
+      return;
+    }
+    // if we have found a new device
     mPwCollection.fetchPwsResults(new PwsResultCallback() {
       long mPwsTripTimeMillis = 0;
 

--- a/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
@@ -41,6 +41,7 @@ public class PhysicalWebCollection {
   private Map<String, byte[]> mIconUrlToIconMap;
   private Set<String> mPendingBroadcastUrls;
   private Set<String> mPendingIconUrls;
+  private Set<String> mFailedResolveUrls;
 
   /**
    * Construct a PhysicalWebCollection.
@@ -52,14 +53,18 @@ public class PhysicalWebCollection {
     mIconUrlToIconMap = new HashMap<>();
     mPendingBroadcastUrls = new HashSet<>();
     mPendingIconUrls = new HashSet<>();
+    mFailedResolveUrls = new HashSet<>();
   }
 
   /**
    * Add a UrlDevice to the collection.
    * @param urlDevice The UrlDevice to add.
+   * @return true if the device already existed in the map
    */
-  public void addUrlDevice(UrlDevice urlDevice) {
+  public boolean addUrlDevice(UrlDevice urlDevice) {
+    boolean alreadyFound = mDeviceIdToUrlDeviceMap.containsKey(urlDevice.getId());
     mDeviceIdToUrlDeviceMap.put(urlDevice.getId(), urlDevice);
+    return alreadyFound;
   }
 
   /**
@@ -348,7 +353,7 @@ public class PhysicalWebCollection {
     Set<String> newIconUrls = new HashSet<>();
     for (UrlDevice urlDevice : mDeviceIdToUrlDeviceMap.values()) {
       String url = urlDevice.getUrl();
-      if (!mPendingBroadcastUrls.contains(url)) {
+      if (!mPendingBroadcastUrls.contains(url) && !mFailedResolveUrls.contains(url)) {
         PwsResult pwsResult = mBroadcastUrlToPwsResultMap.get(url);
         if (pwsResult == null) {
           newResolveUrls.add(url);
@@ -378,6 +383,7 @@ public class PhysicalWebCollection {
 
       @Override
       public void onPwsResultAbsent(String url) {
+        mFailedResolveUrls.add(url);
         pwsResultCallback.onPwsResultAbsent(url);
       }
 


### PR DESCRIPTION
When a URL is not resolved by the PWS, the client
will continue to attempt to fetch a result unnecessarily.
Also, we refetch whenever we see a new beacon rather than
only when we see a beacon not seen during the current scan