### PR TITLE
Cache icons in PhysicalWebcollection

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UrlDeviceDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UrlDeviceDiscoveryService.java
@@ -194,7 +194,6 @@ public class UrlDeviceDiscoveryService extends Service
     super.onCreate();
     initialize();
     restoreCache();
-
     cancelNotifications();
     mHandler.postDelayed(mFirstScanTimeout, FIRST_SCAN_TIME_MILLIS);
     mHandler.postDelayed(mSecondScanTimeout, SECOND_SCAN_TIME_MILLIS);
@@ -257,11 +256,10 @@ public class UrlDeviceDiscoveryService extends Service
 
   @Override
   public void onUrlDeviceDiscovered(UrlDevice urlDevice) {
-    // check if device has already been discovered
-    if (mPwCollection.addUrlDevice(urlDevice)) {
-      return;
-    }
-    // if we have found a new device
+    // Add Device and fetch results
+    // Don't short circuit because icons
+    // and metadata may not be fetched
+    mPwCollection.addUrlDevice(urlDevice);
     mPwCollection.fetchPwsResults(new PwsResultCallback() {
       long mPwsTripTimeMillis = 0;
 

--- a/java/libs/build.gradle
+++ b/java/libs/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     compile 'org.json:json:20140107'
     testCompile 'junit:junit:4.11'
     testCompile 'org.skyscreamer:jsonassert:1.2.3'
+    compile 'commons-codec:commons-codec:1.10'
 }
 
 task integrationTest(type: Test) {

--- a/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
@@ -15,14 +15,18 @@
  */
 package org.physical_web.collection;
 
+import org.apache.commons.codec.binary.Base64;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,6 +39,7 @@ public class PhysicalWebCollection {
   private static final String SCHEMA_VERSION_KEY = "schema";
   private static final String DEVICES_KEY = "devices";
   private static final String METADATA_KEY = "metadata";
+  private static final String ICON_MAP_KEY = "iconmap";
   private PwsClient mPwsClient;
   private Map<String, UrlDevice> mDeviceIdToUrlDeviceMap;
   private Map<String, PwsResult> mBroadcastUrlToPwsResultMap;
@@ -132,6 +137,13 @@ public class PhysicalWebCollection {
     }
     jsonObject.put(METADATA_KEY, metadata);
 
+    JSONObject iconMap = new JSONObject();
+    for (String iconUrl : mIconUrlToIconMap.keySet()) {
+      iconMap.put(iconUrl, new String(Base64.encodeBase64(getIcon(iconUrl)),
+          Charset.forName("UTF-8")));
+    }
+    jsonObject.put(ICON_MAP_KEY, iconMap);
+
     jsonObject.put(SCHEMA_VERSION_KEY, SCHEMA_VERSION);
     return jsonObject;
   }
@@ -169,6 +181,12 @@ public class PhysicalWebCollection {
       collection.addMetadata(pwsResult);
     }
 
+    JSONObject iconMap = jsonObject.getJSONObject(ICON_MAP_KEY);
+    for (Iterator<String> iconUrls = iconMap.keys(); iconUrls.hasNext();) {
+      String iconUrl = iconUrls.next();
+      collection.addIcon(iconUrl, Base64.decodeBase64(
+          iconMap.getString(iconUrl).getBytes(Charset.forName("UTF-8"))));
+    }
     return collection;
   }
 

--- a/java/libs/src/test/java/org/physical_web/collection/PhysicalWebCollectionTest.java
+++ b/java/libs/src/test/java/org/physical_web/collection/PhysicalWebCollectionTest.java
@@ -48,6 +48,7 @@ public class PhysicalWebCollectionTest {
   private static final String ICON_URL2 = "http://physical-web.org/favicon.ico";
   private static final String GROUP_ID1 = "group1";
   private static final String GROUP_ID2 = "group2";
+  private static final byte[] ICON1 = new byte[] { 0x10 , 0x00 };
   private PhysicalWebCollection physicalWebCollection1;
   private JSONObject jsonObject1;
 
@@ -70,6 +71,7 @@ public class PhysicalWebCollectionTest {
         .build();
     physicalWebCollection1.addUrlDevice(urlDevice);
     physicalWebCollection1.addMetadata(pwsResult);
+    physicalWebCollection1.addIcon(ICON_URL1, ICON1);
     jsonObject1 = new JSONObject("{"
         + "    \"schema\": 1,"
         + "    \"devices\": [{"
@@ -83,7 +85,10 @@ public class PhysicalWebCollectionTest {
         + "        \"description\": \"" + DESCRIPTION1 + "\","
         + "        \"iconurl\": \"" + ICON_URL1 + "\","
         + "        \"groupid\": \"" + GROUP_ID1 + "\""
-        + "    }]"
+        + "    }],"
+        + "    \"iconmap\": {"
+        + "        \"" + ICON_URL1 + "\": \"" + "EAA=" + "\""
+        + "    }"
         + "}");
   }
 


### PR DESCRIPTION
Writes icons to cache along with PwsResult data instead
of fetching them each time on resume