### PR TITLE
RSSI Crash

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UrlDeviceDiscoveryService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/UrlDeviceDiscoveryService.java
@@ -184,6 +184,12 @@ public class UrlDeviceDiscoveryService extends Service
       JSONObject serializedCollection = new JSONObject(prefs.getString(PW_COLLECTION_KEY, null));
       mPwCollection = PhysicalWebCollection.jsonDeserialize(serializedCollection);
       Utils.setPwsEndpoint(this, mPwCollection);
+      // replace TxPower and RSSI data after restoring cache
+      for (UrlDevice urlDevice : mPwCollection.getUrlDevices()) {
+        if (Utils.isBleUrlDevice(urlDevice)) {
+          Utils.updateRegion(urlDevice);
+        }
+      }
     } catch (JSONException e) {
       Log.e(TAG, "Could not restore Physical Web collection cache", e);
     } catch (PhysicalWebCollectionException e) {

--- a/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
+++ b/java/libs/src/main/java/org/physical_web/collection/PhysicalWebCollection.java
@@ -117,6 +117,14 @@ public class PhysicalWebCollection {
   }
 
   /**
+   * Gets all UrlDevices stored in the collection
+   * @return List of UrlDevices
+   */
+  public List<UrlDevice> getUrlDevices() {
+    return (List) new ArrayList(mDeviceIdToUrlDeviceMap.values());
+  }
+
+  /**
    * Create a JSON object that represents this data structure.
    * @return a JSON serialization of this data structure.
    */


### PR DESCRIPTION
After retrieving the cache, since we have not cached the RegionResolver
we have to insert the Txpower and Rssi data for each UrlDevice.
