### PR TITLE
Tweek UI to better show action in demos

### DIFF
--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/DemosFragment.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/DemosFragment.java
@@ -21,6 +21,7 @@ import org.physical_web.demos.WifiDirectHelloWorld;
 
 import android.app.ListFragment;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.View;
@@ -71,11 +72,20 @@ public class DemosFragment extends ListFragment {
     } else {
       demo.startDemo();
     }
+    setBackgroundColor(v, demo.isDemoStarted());
   }
 
   private void initialize() {
     mAdapter.addItem(new FatBeaconHelloWorld(getActivity()));
     mAdapter.addItem(new WifiDirectHelloWorld(getActivity()));
+  }
+
+  private void setBackgroundColor(View view, boolean isStarted) {
+    if (isStarted) {
+      view.setBackgroundColor(ContextCompat.getColor(getActivity(), R.color.physical_web_logo));
+    } else {
+      view.setBackgroundColor(0xFFFFFFFF);
+    }
   }
 
   private class DemosAdapter extends BaseAdapter {
@@ -111,6 +121,7 @@ public class DemosFragment extends ListFragment {
       }
       ((TextView) view.findViewById(R.id.demo_title)).setText(demos.get(i).getTitle());
       ((TextView) view.findViewById(R.id.demo_summary)).setText(demos.get(i).getSummary());
+      setBackgroundColor(view, demos.get(i).isDemoStarted());
       return view;
     }
   }

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/FileBroadcastService.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/FileBroadcastService.java
@@ -25,6 +25,7 @@ import android.net.Uri;
 import android.net.wifi.p2p.WifiP2pManager;
 import android.os.IBinder;
 import android.support.v4.app.NotificationManagerCompat;
+import android.widget.Toast;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -118,6 +119,8 @@ public class FileBroadcastService extends Service {
           Log.d(TAG, "discovery failed " + reasonCode);
         }
       });
+      Toast.makeText(this, R.string.wifi_direct_broadcasting_confirmation, Toast.LENGTH_SHORT)
+          .show();
       return START_STICKY;
     }
 

--- a/android/PhysicalWeb/app/src/main/res/values/strings.xml
+++ b/android/PhysicalWeb/app/src/main/res/values/strings.xml
@@ -73,6 +73,7 @@
     <string name="FatBeacon_URL">"Local BLE page @ "</string>
     <string name="fatbeacon_broadcasting_confirmation">Broadcasting FatBeacon</string>
     <string name="fatbeacon_notification_title">Physical Web is sharing as a FatBeacon</string>
+    <string name="wifi_direct_broadcasting_confirmation">Broadcasting with Wi-Fi Direct</string>
     <string name="wifi_direct_notification_title">Physical Web is sharing with Wi-Fi Direct</string>
     <string name="demos">Demos</string>
     <string name="fat_beacon_demo_title">FatBeacon Demo</string>


### PR DESCRIPTION
When a user clicked on a Demo all that happened was a Toast and the notification. Scott wanted there to be a little something more to notify users they clicked on something.