### PR TITLE
Fix double downloads and zombie downloads

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,3 +36,4 @@ devunwired
 ColeMurray
 edent
 kevinahuber
+angst7

--- a/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
+++ b/android/PhysicalWeb/app/src/main/java/org/physical_web/physicalweb/NearbyBeaconsFragment.java
@@ -83,6 +83,7 @@ public class NearbyBeaconsFragment extends ListFragment
   private boolean mMissedEmptyGroupIdQueue = false;
   private SwipeDismissListViewTouchListener mTouchListener;
   private WifiDirectConnect mWifiDirectConnect;
+  private BluetoothSite mBluetoothSite;
 
   // The display of gathered urls happens as follows
   // 0. Begin scan
@@ -205,6 +206,7 @@ public class NearbyBeaconsFragment extends ListFragment
     ListView listView = (ListView) rootView.findViewById(android.R.id.list);
     mDiscoveryServiceConnection = new DiscoveryServiceConnection();
     mWifiDirectConnect = new WifiDirectConnect(getActivity());
+    mBluetoothSite = new BluetoothSite(getActivity());
     mTouchListener =
       new SwipeDismissListViewTouchListener(
               listView,
@@ -285,7 +287,9 @@ public class NearbyBeaconsFragment extends ListFragment
       // Initiate WifiDirect Connection request to device
       mWifiDirectConnect.connect(item.getUrlDevice(), pwsResult.getTitle());
     } else if (Utils.isFatBeaconDevice(item.getUrlDevice())) {
-      (new BluetoothSite(getActivity())).connect(pwsResult.getSiteUrl(), pwsResult.getTitle());
+      if (!mBluetoothSite.isRunning()) {
+        mBluetoothSite.connect(pwsResult.getSiteUrl(), pwsResult.getTitle());
+      }
     } else {
       Intent intent = Utils.createNavigateToUrlIntent(pwsResult);
       startActivity(intent);


### PR DESCRIPTION
Fixes #803.  

There still seems to be an edge case that can cause the app to misbehave if you rapidly and repeatedly tap on a Fatbeacon.
