### PR TITLE
Add FatBeacon Implementation for Eddystone

### DIFF
--- a/nodejs/FatBeaconPeripheral/FatBeacon.js
+++ b/nodejs/FatBeaconPeripheral/FatBeacon.js
@@ -1,0 +1,54 @@
+var bleno = require('bleno');
+var eddystoneBeacon = require('eddystone-beacon');
+
+/***********************Altering Library Functions**************************/
+/**
+ * In order to broadcast in the fatbeacon format, we override several
+ * functions in the advertisement-data module of the eddystone-beacon library.
+ */
+var AdvertisementData = 
+        require('eddystone-beacon/lib/util/advertisement-data');
+var Eir = require('eddystone-beacon/lib/util/eir');
+
+var FAT_BEACON_FRAME_TYPE = 0x0e;
+var MAX_URL_LENGTH = 18;
+var SERVICE_UUID = 'feaa';
+
+/**
+ * this patch ensures that the correct Fatbeacon eir flag (0x06) is added
+ * to the packet instead of the library standard flag.
+ */
+AdvertisementData.makeEirData = function(serviceData) {
+  var eir = new Eir();
+  eir.addFlags(0x06);
+  eir.add16BitCompleteServiceList([SERVICE_UUID]);
+  eir.addServiceData(SERVICE_UUID, serviceData);
+  return eir.buffer();
+}
+
+/**
+ * This patch alters the method signature to accept a name instead of a url.
+ * It also encodes the name in hex instead of the libraries url encoding
+ * format. Lastly, it adds the Fatbeacon header to the packet.
+ */
+AdvertisementData.makeUrlBuffer = function(name) {
+  console.log(`AdvertisementData.makeUrlBuffer called with: ${name}`);
+  
+  var encodedName = Buffer.from(name);
+  if (encodedName.length > MAX_URL_LENGTH) {
+    throw new Error(`Encoded Name must be less than ${MAX_URL_LENGTH} bytes.` +
+                    ` It is currently ${encodedName.length} bytes.`);
+  }
+
+  var serviceData = Buffer.concat([
+    Buffer.from([0x10, 0xba, FAT_BEACON_FRAME_TYPE]), //FatBeacon Header
+    encodedName
+  ]);
+
+  return AdvertisementData.makeEirData(serviceData);
+}
+
+/*********************************************************/
+
+// Start Advertising name.
+eddystoneBeacon.advertiseUrl('New Fatbeacon');

--- a/nodejs/FatBeaconPeripheral/README.md
+++ b/nodejs/FatBeaconPeripheral/README.md
@@ -1,0 +1,34 @@
+FatBeacon on Raspberry Pi
+=========================
+
+This is a nodejs implementation of a Fatbeacon developed on a Raspberry Pi 3.
+It will advertise a connectable Fatbeacon over Bluetooth Low Energy (BLE). 
+When the central (client) connects to the peripheral (Fatbeacon/server), the
+central will attempt to read the webpageCharacteristic, which serves a HTML.
+There is also the option to have this data be compressed with gzip.
+
+Instructions for Raspbian:
+--------------------------
+1. Clone repository onto Pi. If you're using a Pi2 or earlier, make sure you
+have a bluetooth chip installed.
+2. Make sure you have nodejs
+
+   ```$ node -v```
+
+If not, then run
+
+    ```$ sudo apt install nodejs```
+
+3. For bleno make sure bluetooth, bluez, libbluetooth-dev, and libudev-dev 
+   are installed
+
+   ```$ sudo apt-get install bluetooth bluez libbluetooth-dev libudev-dev```
+
+4. Navigate to the repository directory and run
+
+    ```$ sudo npm install```
+
+This should download all required nodejs libraries.
+5. To run
+
+    ```$ sudo node FatBeacon.js```


### PR DESCRIPTION
This change sets up a basic eddystone-beacon
and alters eddystone-beacon libraries to convert
the eddystone to a FatBeacon.