### PR TITLE
Gatt start

### DIFF
--- a/nodejs/FatBeaconPeripheral/FatBeacon.js
+++ b/nodejs/FatBeaconPeripheral/FatBeacon.js
@@ -1,18 +1,21 @@
 var bleno = require('bleno');
 var eddystoneBeacon = require('eddystone-beacon');
+var webpageCharacteristic = require('./webpageCharacteristic');
+
+var SERVICE_UUID = 'ae5946d4-e587-4ba8-b6a5-a97cca6affd3';
 
 /***********************Altering Library Functions**************************/
 /**
  * In order to broadcast in the fatbeacon format, we override several
  * functions in the advertisement-data module of the eddystone-beacon library.
  */
-var AdvertisementData = 
+var AdvertisementData =
         require('eddystone-beacon/lib/util/advertisement-data');
 var Eir = require('eddystone-beacon/lib/util/eir');
 
 var FAT_BEACON_FRAME_TYPE = 0x0e;
 var MAX_URL_LENGTH = 18;
-var SERVICE_UUID = 'feaa';
+var ADVERTISING_HEADER_UUID = 'feaa';
 
 /**
  * this patch ensures that the correct Fatbeacon eir flag (0x06) is added
@@ -21,8 +24,8 @@ var SERVICE_UUID = 'feaa';
 AdvertisementData.makeEirData = function(serviceData) {
   var eir = new Eir();
   eir.addFlags(0x06);
-  eir.add16BitCompleteServiceList([SERVICE_UUID]);
-  eir.addServiceData(SERVICE_UUID, serviceData);
+  eir.add16BitCompleteServiceList([ADVERTISING_HEADER_UUID]);
+  eir.addServiceData(ADVERTISING_HEADER_UUID, serviceData);
   return eir.buffer();
 }
 
@@ -33,7 +36,7 @@ AdvertisementData.makeEirData = function(serviceData) {
  */
 AdvertisementData.makeUrlBuffer = function(name) {
   console.log(`AdvertisementData.makeUrlBuffer called with: ${name}`);
-  
+
   var encodedName = Buffer.from(name);
   if (encodedName.length > MAX_URL_LENGTH) {
     throw new Error(`Encoded Name must be less than ${MAX_URL_LENGTH} bytes.` +
@@ -49,6 +52,29 @@ AdvertisementData.makeUrlBuffer = function(name) {
 }
 
 /*********************************************************/
+
+var characteristic = new webpageCharacteristic();
+var data = new Buffer.from('Hello World of FatBeacon!');
+characteristic.onWriteRequest(data, 0, null, null);
+
+var service = new bleno.PrimaryService({
+  uuid: SERVICE_UUID,
+  characteristics: [
+    characteristic
+  ]
+});
+
+bleno.once('advertisingStart', function(err) {
+  
+  if(err) {
+    throw err;
+  }
+
+  console.log('on - advertisingStart');
+  bleno.setServices([
+    service
+  ]);
+});
 
 // Start Advertising name.
 eddystoneBeacon.advertiseUrl('New Fatbeacon');

--- a/nodejs/FatBeaconPeripheral/webpageCharacteristic.js
+++ b/nodejs/FatBeaconPeripheral/webpageCharacteristic.js
@@ -1,0 +1,49 @@
+var util = require('util');
+var bleno = require('bleno');
+var CHARACTERISTIC_UUID = 'd1a517f0-2499-46ca-9ccc-809bc1c966fa';
+
+var WebpageCharacteristic = function() {
+  WebpageCharacteristic.super_.call(this, {
+    uuid: CHARACTERISTIC_UUID,
+    properties: ['read'],
+    value: null
+  });
+
+  this._value = Buffer.alloc(0);
+  this._updateValueCallback = null;
+};
+
+util.inherits(WebpageCharacteristic, bleno.Characteristic);
+
+WebpageCharacteristic.prototype.onReadRequest = function(offset, callback) {
+  console.log(`Reading - ${this._value}`);
+  callback(this.RESULT_SUCCESS, this._value);
+};
+
+WebpageCharacteristic.prototype.onWriteRequest = function(data, offset, withoutResponse, callback) {
+  this._value = data;
+
+  console.log(`Writing - ${this._value}`);
+
+  if (this._updateValueCallback) {
+    console.log('WebpageCharacteristic - onWriteRequest: notifying');
+
+    this._updateValueCallback(this._value);
+  }
+
+  if(callback) {
+    callback(this.RESULT_SUCCESS);
+  }
+};
+
+WebpageCharacteristic.prototype.onSubscribe = function(maxValueSize, updateValueCallback) {
+  console.log('WebpageCharacteristic - onSubscribe');
+  this._updateValueCallback = updateValueCallback;
+};
+
+WebpageCharacteristic.prototype.onUnsubscribe = function() {
+  console.log('WebpageCharacteristic - onUnsubscribe');
+  this._updateValueCallback = null;
+};
+
+module.exports = WebpageCharacteristic;


### PR DESCRIPTION
This change allows for the fatbeacon to become connectable. It also creates a webpagecharacteristic for the fatbeacon for the central to read from, when it tries to connect. The data for the characteristic are written in at runtime before advertising, as opposed to hard-coded in.