### PR TITLE
Change MTU size of BLE transfer packets

### DIFF
--- a/nodejs/FatBeaconPeripheral/FatBeacon.js
+++ b/nodejs/FatBeaconPeripheral/FatBeacon.js
@@ -13,10 +13,14 @@ var SERVICE_UUID = 'ae5946d4-e587-4ba8-b6a5-a97cca6affd3';
 var AdvertisementData =
         require('eddystone-beacon/lib/util/advertisement-data');
 var Eir = require('eddystone-beacon/lib/util/eir');
+var Gatt = require('bleno/lib/hci-socket/gatt');
 
 var FAT_BEACON_FRAME_TYPE = 0x0e;
 var MAX_URL_LENGTH = 18;
 var ADVERTISING_HEADER_UUID = 'feaa';
+var ATT_OP_MTU_RESP = 0x03;  // Refer to bleno/lib/hci-socket/gatt for doc
+var MIN_MTU = 23;
+var MAX_MTU = 505;
 
 /**
  * this patch ensures that the correct Fatbeacon eir flag (0x06) is added
@@ -52,14 +56,41 @@ AdvertisementData.makeUrlBuffer = function(name) {
   return AdvertisementData.makeEirData(serviceData);
 }
 
+/**
+ * This allows us to change the negotiate the MTU size from 0 - 505. We have
+ * set REQUESTING_MTU to 505 for maximum transfer rate.
+ */
+Gatt.prototype.handleMtuRequest = function(request) {
+  var mtu = request.readUInt16LE(1);
+ 
+  if (mtu < MIN_MTU) {
+    mtu = MIN_MTU;
+  } else if (mtu > MAX_MTU) {
+    mtu = MAX_MTU;
+  }
+
+  this._mtu = mtu;
+
+  this.emit('mtuChange', this._mtu);
+
+  var response = Buffer.alloc(3);
+
+  response.writeUInt8(ATT_OP_MTU_RESP, 0);
+  response.writeUInt16LE(mtu, 1);
+
+  return response;
+};
+
 /*********************************************************/
 
 var characteristic = new webpageCharacteristic();
 
 fs.readFile("./html/fatBeaconDefault.html", function(err, data) {
-  if(err) throw err;
+  if (err) {
+    throw err;
+  }
+
   characteristic.onWriteRequest(data, 0, null, null);
-  console.log(service);
 });
 
 var service = new bleno.PrimaryService({
@@ -71,7 +102,7 @@ var service = new bleno.PrimaryService({
 
 bleno.once('advertisingStart', function(err) {
   
-  if(err) {
+  if (err) {
     throw err;
   }
 

--- a/nodejs/FatBeaconPeripheral/webpageCharacteristic.js
+++ b/nodejs/FatBeaconPeripheral/webpageCharacteristic.js
@@ -12,7 +12,7 @@ var WebpageCharacteristic = function() {
   this._value = Buffer.alloc(0);
   this._updateValueCallback = null;
 
-  this._mtuSize = 251;  // 5 less than the specified mtu
+  this._mtuSize = 500;  // 5 less than the specified mtu
   this._start = 0;
   this._end = this._mtuSize;
 };
@@ -34,7 +34,7 @@ WebpageCharacteristic.prototype.onReadRequest = function(offset, callback) {
 WebpageCharacteristic.prototype.onWriteRequest = function(data, offset, withoutResponse, callback) {
   this._value = data;
 
-  console.log(`Writing - ${this._value}`);
+  console.log(`Writing ${this._value.length} bytes`);
 
   if (this._updateValueCallback) {
     console.log('WebpageCharacteristic - onWriteRequest: notifying');


### PR DESCRIPTION
This change allows us to monkeypatch the increase in MTU size to
optimize the data transfer rate. Currently, we are setting it at
505, which is the limit the android can accept.